### PR TITLE
Feature/headless

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,14 +2,18 @@
 Vagrant.configure("2") do |config|
 
   # basebox
-  config.vm.box = "tknerr/ubuntu2004-desktop"
-  config.vm.box_version = "0.1.0"
+  config.vm.box = "generic/ubuntu2004"
+  config.vm.box_version = "3.0.16"
+
+  # name of the box based on the directory
+  config.vm.define File.basename(File.dirname(__FILE__))
 
   # hostname
   config.vm.hostname = 'dev-vm'
 
   # virtualbox specific customizations
   config.vm.provider "virtualbox" do |vbox, override|
+    vbox.gui = true
     vbox.name = "Linux Developer VM"
     vbox.cpus = 4
     vbox.memory = 4096
@@ -20,6 +24,7 @@ Vagrant.configure("2") do |config|
 
   # vmware specific customizations
   config.vm.provider "vmware_desktop" do |vmware, override|
+    vmware.gui = true
     vmware.vmx["displayname"] = "Linux Developer VM"
     vmware.vmx["numvcpus"] = "4"
     vmware.vmx["memsize"] = "4096"
@@ -27,6 +32,8 @@ Vagrant.configure("2") do |config|
     vmware.vmx["usb.pcislotnumber"] = "33"
     vmware.vmx["usb_xhci.present"] = "TRUE"
   end
+
+  config.vm.synced_folder ".", "/vagrant", mount_options: ["ro"]
 
   # create new login user
   config.vm.provision "shell", privileged: true, path: 'scripts/setup-vm-user.sh',

--- a/roles/gnome/tasks/main.yaml
+++ b/roles/gnome/tasks/main.yaml
@@ -1,0 +1,13 @@
+---
+- name: Install the GNOME Desktop
+  apt:
+    name:
+      - gdm3
+      - ubuntu-desktop
+      - gnome
+      - gnome-shell-extension-desktop-icons
+      - fonts-noto
+    state: present
+    install_recommends: no
+  notify:
+    - restart display-manager

--- a/roles/readme/tasks/main.yml
+++ b/roles/readme/tasks/main.yml
@@ -1,11 +1,4 @@
 ---
-- name: Install the GNOME Desktop Icons extension
-  apt:
-    name: gnome-shell-extension-desktop-icons
-    state: present
-  notify:
-    - restart display-manager
-
 - name: Ensure the ~/Desktop directory exists
   file:
     path: ~/Desktop

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -39,6 +39,7 @@ copy_repo_and_symlink_self() {
   if mountpoint -q /vagrant; then
     step "Copy /vagrant to $REPO_ROOT"
     rsync -avh --progress /vagrant/ $REPO_ROOT/ --delete --exclude-from /vagrant/.gitignore
+    chmod +x $REPO_ROOT/scripts/*.sh
     step "Symlinking 'update-vm' script"
     sudo ln -sf $REPO_ROOT/scripts/update-vm.sh /usr/local/bin/update-vm
   else

--- a/site.yml
+++ b/site.yml
@@ -12,3 +12,4 @@
     - { role: readme, tags: "readme" }
     - { role: ansible-lint, tags: "ansible-lint" }
     - { role: testinfra, tags: "testinfra" }
+    - { role: gnome, tags: "gnome" }


### PR DESCRIPTION
Hello there!
This pull request follows two goals:
* Make the base box be a generic one, to remove a layer of dependencies (`generic/` boxes have higher usage than `tknerr/` ones)
* Make the installation of Gnome a dedicated one, to allow for personal preferences about desktop environment - if one is needed at all

The only slight downside is that the first installation takes a bit longer than previously, since the installation of Gnome takes a while. 

I'm quite new to Ansible and have no experience in writing tests for that, so I would need help if tests are required for this.