### PR TITLE
Switch to generic/ubuntu2004 basebox + ubuntu-desktop metapackage

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,14 +2,15 @@
 Vagrant.configure("2") do |config|
 
   # basebox
-  config.vm.box = "tknerr/ubuntu2004-desktop"
-  config.vm.box_version = "0.1.0"
+  config.vm.box = 'generic/ubuntu2004'
+  config.vm.box_version = '3.1.6'
 
   # hostname
   config.vm.hostname = 'dev-vm'
 
   # virtualbox specific customizations
   config.vm.provider "virtualbox" do |vbox, override|
+    vbox.gui = true
     vbox.cpus = 4
     vbox.memory = 4096
     vbox.customize ["modifyvm", :id, "--name", "Linux Developer VM"]
@@ -21,6 +22,7 @@ Vagrant.configure("2") do |config|
 
   # vmware specific customizations
   config.vm.provider "vmware_desktop" do |vmware, override|
+    vmware.gui = true
     vmware.vmx["displayname"] = "Linux Developer VM"
     vmware.vmx["numvcpus"] = "4"
     vmware.vmx["memsize"] = "4096"
@@ -28,6 +30,9 @@ Vagrant.configure("2") do |config|
     vmware.vmx["usb.pcislotnumber"] = "33"
     vmware.vmx["usb_xhci.present"] = "TRUE"
   end
+
+  # make sure the current directory is mounted under /vagrant
+  config.vm.synced_folder ".", "/vagrant", mount_options: ["rw"]
 
   # create new login user
   config.vm.provision "shell", privileged: true, path: 'scripts/setup-vm-user.sh',

--- a/roles/desktop/tasks/main.yml
+++ b/roles/desktop/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Install the Ubuntu Desktop (meta-)package
+  apt:
+    package: ubuntu-desktop
+    state: present
+    install_recommends: yes
+  notify:
+    - restart display-manager

--- a/roles/desktop/tasks/main.yml
+++ b/roles/desktop/tasks/main.yml
@@ -7,3 +7,11 @@
     install_recommends: yes
   notify:
     - restart display-manager
+
+- name: Install the VMware tools (so that we can copy/paste between VM and host)
+  apt:
+    package:
+      - open-vm-tools
+      - open-vm-tools-desktop
+    state: present
+  when: ansible_virtualization_type == 'VMware'

--- a/site.yml
+++ b/site.yml
@@ -10,6 +10,7 @@
 
 - hosts: localhost
   roles:
+    - { role: desktop, tags: "desktop" }
     - { role: readme, tags: "readme" }
     - { role: ansible-lint, tags: "ansible-lint" }
     - { role: testinfra, tags: "testinfra" }


### PR DESCRIPTION
This is based on PR #2 from @zuehlke-hach, but with a few modifications:

* installs `ubuntu-desktop` metapackage with "install-recommends=yes" to be closer to the actual Ubuntu Desktop distro
* updates to latest version of generic boxes
* installs VMware Desktop tools so that Copy/Paste between host and VM is working
* updates the README with specific instructions for building and packaging VMware images of the developer VM

@zuehlke-hach thanks a lot for the idea and the initial PR! I hope you are fine with the changes in here. Let me know though... :)