### PR TITLE
Swtich to VMSVGA graphics driver

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,7 @@ Vagrant.configure("2") do |config|
     vbox.memory = 4096
     vbox.customize ["modifyvm", :id, "--usb", "on"]
     vbox.customize ["modifyvm", :id, "--accelerate3d", "off"]
+    vbox.customize ["modifyvm", :id, "--graphicscontroller", "vmsvga"]
     vbox.customize ["modifyvm", :id, "--vrde", "off"]
   end
 


### PR DESCRIPTION
Swtich to VMSVGA graphics driver which is supposed to be the default for Linux VMs in Virtualbox

(in fact, by default it used VBoxSVGA and this resulted in an "invalid configuration detected" warning when you browsed through the settings...)