### PR TITLE
gitignore the __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant/
+__pycache__/


### PR DESCRIPTION
ignores the `spec/__pytest__/` directory 