### PR TITLE
Update ansible tooling

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+skip_list:
+  - role-name

--- a/roles/ansible-lint/tasks/main.yml
+++ b/roles/ansible-lint/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 
-- name: Install ansible-lint at version 4.2.0
-  pip: state=present name=ansible-lint version=4.2.0
+- name: Install ansible-lint at version 5.0.12
+  pip: state=present name=ansible-lint version=5.0.12

--- a/roles/readme/tasks/main.yml
+++ b/roles/readme/tasks/main.yml
@@ -10,6 +10,8 @@
   file:
     path: ~/Desktop
     state: directory
+    mode: 0755
+
   become: yes
   become_user: "{{ ansible_env.SUDO_USER }}"
 
@@ -17,5 +19,6 @@
   copy:
     src: README.md
     dest: ~/Desktop/README.md
+    mode: 0644
   become: yes
   become_user: "{{ ansible_env.SUDO_USER }}"

--- a/roles/testinfra/tasks/main.yml
+++ b/roles/testinfra/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: Install testinfra at version 5.0.0
-  pip: state=present name=testinfra version=5.0.0
+- name: Install testinfra at version 6.3.0
+  pip: state=present name=pytest-testinfra version=6.3.0
 
-- name: Install pytest-spec formatter at version 2.0.0
-  pip: state=present name=pytest-spec version=2.0.0
+- name: Install pytest-spec formatter at version 3.2.0
+  pip: state=present name=pytest-spec version=3.2.0

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -72,7 +72,7 @@ verify_vm() {
   ansible-lint --force-color
 
   step "run integration tests"
-  py.test -v --color=yes --spec spec/*.py
+  py.test --color=yes --spec spec/*.py
 }
 
 big_step() {

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 
 # variables
 REPO_ROOT=~/vm-setup
-ANSIBLE_VERSION=2.9.6
+ANSIBLE_VERSION=2.9.22
 
 # exports
 export ANSIBLE_FORCE_COLOR=true

--- a/spec/test_ansible.py
+++ b/spec/test_ansible.py
@@ -1,12 +1,12 @@
 
-def test_ansible_is_installed_at_version_2_9_6_(host):
+def test_ansible_is_installed_at_version_2_9_22_(host):
     cmd = host.run("pip3 show --disable-pip-version-check ansible")
     assert cmd.rc is 0
-    assert "Name: ansible\nVersion: 2.9.6" in cmd.stdout
+    assert "Name: ansible\nVersion: 2.9.22" in cmd.stdout
 
 def test_ansible_commands_are_found_(host):
     assert host.run('which ansible').rc is 0
     assert host.run('which ansible-playbook').rc is 0
 
-def test_ansible_version_command_reports_version_2_9_6_(host):
-    assert '2.9.6' in host.run('ansible --version').stdout
+def test_ansible_version_command_reports_version_2_9_22_(host):
+    assert '2.9.22' in host.run('ansible --version').stdout

--- a/spec/test_ansible_lint.py
+++ b/spec/test_ansible_lint.py
@@ -1,11 +1,11 @@
 
-def test_ansible_lint_is_installed_at_version_4_2_0_(host):
+def test_ansible_lint_is_installed_at_version_5_0_12_(host):
     cmd = host.run("pip3 show --disable-pip-version-check ansible-lint")
     assert cmd.rc is 0
-    assert "Name: ansible-lint\nVersion: 4.2.0" in cmd.stdout
+    assert "Name: ansible-lint\nVersion: 5.0.12" in cmd.stdout
 
 def test_ansible_lint_command_is_found_(host):
     assert host.run('which ansible-lint').rc is 0
 
-def test_ansible_lint_version_command_reports_version_4_2_0_(host):
-    assert '4.2.0' in host.run('ansible-lint --version').stdout
+def test_ansible_lint_version_command_reports_version_5_0_12_(host):
+    assert '5.0.12' in host.run('ansible-lint --version').stdout

--- a/spec/test_testinfra.py
+++ b/spec/test_testinfra.py
@@ -1,10 +1,10 @@
 
-def test_testinfra_is_installed_at_version_5_0_0_(host):
-    cmd = host.run("pip3 show --disable-pip-version-check testinfra")
+def test_testinfra_is_installed_at_version_6_3_0_(host):
+    cmd = host.run("pip3 show --disable-pip-version-check pytest-testinfra")
     assert cmd.rc is 0
-    assert "Name: testinfra\nVersion: 5.0.0" in cmd.stdout
+    assert "Name: pytest-testinfra\nVersion: 6.3.0" in cmd.stdout
 
-def test_pytest_spec_is_installed_at_version_2_0_0_(host):
+def test_pytest_spec_is_installed_at_version_3_2_0_(host):
     cmd = host.run("pip3 show --disable-pip-version-check pytest-spec")
     assert cmd.rc is 0
-    assert "Name: pytest-spec\nVersion: 2.0.0" in cmd.stdout
+    assert "Name: pytest-spec\nVersion: 3.2.0" in cmd.stdout


### PR DESCRIPTION
Updates the ansible tooling:

* ansible to v2.9.22
* testinfra to v6.3.0
* pytest-spec to v3.2.0
* ansible-lint to v5.0.12
