### PR TITLE
Add ~/.bashrc.d directory and load the .bash files therein

### DIFF
--- a/roles/bashrc_d/tasks/main.yml
+++ b/roles/bashrc_d/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: create ~/.bashrc.d directory
+  file:
+    path: ~/.bashrc.d
+    state: directory
+    mode: 0755
+  become: yes
+  become_user: "{{ ansible_env.SUDO_USER }}"
+
+- name: Setup ~/.bashrc to load .bash files from ~/.bashrc.d
+  blockinfile:
+    dest: ~/.bashrc
+    block: |
+      # Load *.bash files from ~/.bashrc.d
+      for config in "$HOME"/.bashrc.d/*.bash ; do
+        . "$config"
+      done
+      unset -v config
+  become: yes
+  become_user: "{{ ansible_env.SUDO_USER }}"

--- a/roles/readme/tasks/main.yml
+++ b/roles/readme/tasks/main.yml
@@ -11,7 +11,6 @@
     path: ~/Desktop
     state: directory
     mode: 0755
-
   become: yes
   become_user: "{{ ansible_env.SUDO_USER }}"
 

--- a/site.yml
+++ b/site.yml
@@ -12,3 +12,4 @@
     - { role: readme, tags: "readme" }
     - { role: ansible-lint, tags: "ansible-lint" }
     - { role: testinfra, tags: "testinfra" }
+    - { role: bashrc_d, tags: "bashrc_d" }

--- a/spec/test_bashrc_d.py
+++ b/spec/test_bashrc_d.py
@@ -1,0 +1,15 @@
+import textwrap
+import os
+
+def test_bashrc_loads_files_from_bashrc_d_(host):
+    bashrc = host.file(f"{os.environ['HOME']}/.bashrc")
+    snippet = textwrap.dedent(
+        '''
+        # Load *.bash files from ~/.bashrc.d
+        for config in "$HOME"/.bashrc.d/*.bash ; do
+          . "$config"
+        done
+        unset -v config
+        '''
+    )
+    assert snippet in bashrc.content_string


### PR DESCRIPTION
Adds a `~/.bashrc.d/` directory and updates `~/.bashrc` to load all the .bash files from that directory.

This allows for setting environment variables or similar reliably across bash shell instances, e.g.:
```yaml
- name: Set JAVA_HOME environment
  copy:
    content: |
      export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
    dest: ~/.bashrc.d/java-home.bash
  become: yes
  become_user: "{{ ansible_env.SUDO_USER }}"
```