### PR TITLE
Setup git PS1 shell prompt via ~/.bashrc.d mechanism

### DIFF
--- a/roles/git/files/git-ps1.bash
+++ b/roles/git/files/git-ps1.bash
@@ -1,0 +1,2 @@
+#!/bin/bash
+export PS1='`if [ $? = 0 ]; then echo "\[\e[32m\] ✔ "; else echo "\[\e[31m\] ✘ "; fi`\[\e[00;37m\]\u\[\e[01;37m\]@\[\e[00;37m\]\h\[\e[01;37m\]:\[\e[01;34m\]\w\[\e[00;34m\] `[[ $(git status 2> /dev/null | head -n4 | tail -n1) != "Changes to be committed:" ]] && echo "\[\e[01;31m\]" || echo "\[\e[01;33m\]"``[[ $(git status 2> /dev/null | tail -n1) != "nothing to commit, working tree clean" ]] || echo "\[\e[01;32m\]"`$(__git_ps1 "(%s)")`echo "\[\e[00m\]"`\$ '

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Make sure Git is installed
+  apt:
+    name: git
+    state: present
+
+- name: Set up the PS1 shell prompt for Git
+  copy:
+    src: git-ps1.bash
+    dest: ~/.bashrc.d/git-ps1.bash
+  become: yes
+  become_user: "{{ ansible_env.SUDO_USER }}"

--- a/site.yml
+++ b/site.yml
@@ -13,3 +13,4 @@
     - { role: ansible-lint, tags: "ansible-lint" }
     - { role: testinfra, tags: "testinfra" }
     - { role: bashrc_d, tags: "bashrc_d" }
+    - { role: git, tags: "git" }

--- a/spec/test_git.py
+++ b/spec/test_git.py
@@ -1,0 +1,18 @@
+import os
+
+def test_git_package_is_installed_(host):
+    assert host.package('git').is_installed
+
+def test_git_command_is_found_(host):
+    assert host.run('which git').rc is 0
+
+def test_git_version_command_reports_version_2_x_(host):
+    assert 'git version 2.' in host.run('git --version').stdout
+
+def test_git_shell_prompt_is_configured_in_bashrc_d_(host):
+    git_ps1 = host.file(f"{os.environ['HOME']}/.bashrc.d/git-ps1.bash")
+    assert git_ps1.exists
+    assert git_ps1.contains('export PS1=')
+
+def test_git_shell_prompt_is_set_in_the_environment_(host):
+    assert '__git_ps1' in host.run('bash -i -c "env | grep ^PS1=; exit \\$?"').stdout


### PR DESCRIPTION
Sets up the `PS1` shell prompt for Git, so that:
* it displays the current branch name
* colors indicate the git status

Working copy clean (green):
![image](https://user-images.githubusercontent.com/365744/122119378-65183b80-ce29-11eb-9970-e2e4ee2f4a6c.png)

Unstaged files (red):
![image](https://user-images.githubusercontent.com/365744/122119431-78c3a200-ce29-11eb-95c0-09ecbe4512c2.png)

Staged files (yellow):
![image](https://user-images.githubusercontent.com/365744/122119473-8a0cae80-ce29-11eb-998e-874e8cec25aa.png)

