### PR TITLE
Partially manage ~/.gitconfig via Ansible

### DIFF
--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -12,3 +12,25 @@
     mode: 0644
   become: yes
   become_user: "{{ ansible_env.SUDO_USER }}"
+
+- name: Supply default configuration entries in ~/.gitconfig
+  git_config:
+    name: "{{ item.key }}"
+    value: "{{ item.value }}"
+    scope: global
+  with_dict:
+    # basic settings
+    core.autocrlf: input
+    pull.rebase: 'true'
+    # useful aliases
+    alias.co: checkout
+    alias.ci: commit
+    alias.br: branch
+    alias.st: status
+    alias.unstage: reset HEAD --
+    alias.slog: log --pretty=oneline --abbrev-commit
+    alias.graph: log --all --oneline --graph --decorate
+    alias.stash-all: stash save --include-untracked
+    alias.prune: fetch --prune
+  become: yes
+  become_user: "{{ ansible_env.SUDO_USER }}"

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -9,5 +9,6 @@
   copy:
     src: git-ps1.bash
     dest: ~/.bashrc.d/git-ps1.bash
+    mode: 0644
   become: yes
   become_user: "{{ ansible_env.SUDO_USER }}"

--- a/spec/test_git.py
+++ b/spec/test_git.py
@@ -1,3 +1,4 @@
+import pytest
 import os
 
 def test_git_package_is_installed_(host):
@@ -16,3 +17,26 @@ def test_git_shell_prompt_is_configured_in_bashrc_d_(host):
 
 def test_git_shell_prompt_is_set_in_the_environment_(host):
     assert '__git_ps1' in host.run('bash -i -c "env | grep ^PS1=; exit \\$?"').stdout
+
+
+def test_gitconfig_configures_rebase_on_pull_(host):
+    __assert_git_config(host, 'pull.rebase', 'true')
+
+def test_gitconfig_configures_autocrlf_input_(host):
+    __assert_git_config(host, 'core.autocrlf', 'input')
+
+@pytest.mark.parametrize('shortcut,command', [
+    ('co', 'checkout'),
+    ('ci', 'commit'),
+    ('br', 'branch'),
+    ('st', 'status'),
+    ('unstage', 'reset HEAD --'),
+    ('slog', 'log --pretty=oneline --abbrev-commit'),
+    ('graph', 'log --all --oneline --graph --decorate')
+])
+def test_gitconfig_provides_alias_(host, shortcut, command):
+    __assert_git_config(host, f"alias.{shortcut}", command)
+
+def __assert_git_config(host, config_key, expected_value):
+    actual_value = host.run(f"git config --global --get {config_key}").stdout.strip()
+    assert actual_value == expected_value


### PR DESCRIPTION
Manage selected `~/.gitconfig` settings via Ansible, such as:
* a set of useful aliases
* essential settings such as "pull.rebase=true" and "core.autocrlf=input"