### PR TITLE
Fix naming of VirtualBox VMs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,9 +10,9 @@ Vagrant.configure("2") do |config|
 
   # virtualbox specific customizations
   config.vm.provider "virtualbox" do |vbox, override|
-    vbox.name = "Linux Developer VM"
     vbox.cpus = 4
     vbox.memory = 4096
+    vbox.customize ["modifyvm", :id, "--name", "Linux Developer VM"]
     vbox.customize ["modifyvm", :id, "--usb", "on"]
     vbox.customize ["modifyvm", :id, "--accelerate3d", "off"]
     vbox.customize ["modifyvm", :id, "--graphicscontroller", "vmsvga"]


### PR DESCRIPTION
It seems that using `vbox.name` is broken with recent versions of Vagrant and VirtualBox, while using the `vbox.customize` approach is working...