### PR TITLE
Correct apt repository for VScode

### DIFF
--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Add Microsoft's VSCode repository into sources list
   apt_repository:
-    repo: deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main
+    repo: deb [arch=amd64] https://packages.microsoft.com/repos/code stable main
     state: present
 
 - name: Install VSCode

--- a/spec/test_vscode.py
+++ b/spec/test_vscode.py
@@ -1,7 +1,7 @@
 import pytest
 
 def test_vscode_apt_sources_list_exists_(host):
-    assert host.file('/etc/apt/sources.list.d/packages_microsoft_com_repos_vscode.list').exists
+    assert host.file('/etc/apt/sources.list.d/packages_microsoft_com_repos_code.list').exists
 
 def test_vscode_apt_key_defined_(host):
     assert 'Microsoft (Release signing) <gpgsecurity@microsoft.com>' in host.run('apt-key list').stdout


### PR DESCRIPTION
The repository URL had changed from "vscode" to "code"