### PR TITLE
Switch to direct .deb package installation for VScode

### DIFF
--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -1,19 +1,8 @@
 ---
 
-- name: Add VSCode apt signing key if not present
-  apt_key:
-    id: BC528686B50D79E339D3721CEB3E94ADBE1229CF
-    url: https://packages.microsoft.com/keys/microsoft.asc
-    state: present
-
-- name: Add Microsoft's VSCode repository into sources list
-  apt_repository:
-    repo: deb [arch=amd64] https://packages.microsoft.com/repos/code stable main
-    state: present
-
-- name: Install VSCode
+- name: Install VSCode version 1.57.1 from .deb package
   apt:
-    name: code
+    deb: https://update.code.visualstudio.com/1.57.1/linux-deb-x64/stable
     state: present
 
 - name: List VSCode Extensions

--- a/spec/test_vscode.py
+++ b/spec/test_vscode.py
@@ -1,16 +1,10 @@
 import pytest
 
-def test_vscode_apt_sources_list_exists_(host):
-    assert host.file('/etc/apt/sources.list.d/packages_microsoft_com_repos_code.list').exists
-
-def test_vscode_apt_key_defined_(host):
-    assert 'Microsoft (Release signing) <gpgsecurity@microsoft.com>' in host.run('apt-key list').stdout
-
 def test_vscode_command_is_found_(host):
     assert host.run('which code').rc is 0
 
-def test_vscode_version_command_succeeds_(host):
-    assert host.run('code --version').rc is 0
+def test_vscode_version_command_reports_version_1_57_1_(host):
+    assert '1.57.1' in host.run('code --version').stdout
 
 @pytest.mark.parametrize('extension', [
     'zbr.vscode-ansible'


### PR DESCRIPTION
..because of 2 reasons:

1. we can control and pin the VSCode version
2. the microsoft package repositories were horribly slow these days -- the direct deb download is much faster