### PR TITLE
Add Docker Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ For the Chef-based equivalent of it, see https://github.com/Zuehlke/linux-develo
 
 These are the main tools included in this developer VM:
 
- * [VSCode](https://code.visualstudio.com/) - as a general purpose (code) editor
+ * [VSCode](https://code.visualstudio.com/) - as a general purpose (code) editor, e.g. for updating the Ansible roles when working from within the developer VM
+ * [Docker](https://www.docker.com/) - as a general purpose container runtime, e.g. for building your applications with a dockerized toolchain
 
 Apart from the above, the following tools are used to set up and maintain this developer VM:
 

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -14,3 +14,9 @@
   apt:
     deb: https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/amd64/docker-ce_20.10.7~3-0~ubuntu-focal_amd64.deb
     state: present
+
+- name: Add VM user to 'docker' group
+  user:
+    name: "{{ ansible_env.SUDO_USER }}"
+    groups: docker
+    append: yes

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Install Containerd 1.4.6
+  apt:
+    deb: https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/amd64/containerd.io_1.4.6-1_amd64.deb
+    state: present
+
+- name: Install Docker CE CLI 20.10.7
+  apt:
+    deb: https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/amd64/docker-ce-cli_20.10.7~3-0~ubuntu-focal_amd64.deb
+    state: present
+
+- name: Install Docker CE Engine 20.10.7
+  apt:
+    deb: https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/amd64/docker-ce_20.10.7~3-0~ubuntu-focal_amd64.deb
+    state: present

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,19 +1,18 @@
 ---
 
-- name: Install Containerd 1.4.6
-  apt:
-    deb: https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/amd64/containerd.io_1.4.6-1_amd64.deb
-    state: present
+- name: Download Docker CE .deb Packages
+  get_url:
+    url: https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/amd64/{{ item.deb_file }}
+    checksum: "sha256:{{ item.sha256sum }}"
+    dest: "{{ download_cache_dir }}/{{ item.deb_file }}"
+    force: no
+  with_items: "{{ docker_deb_packages }}"
 
-- name: Install Docker CE CLI 20.10.7
+- name: Install Docker CE .deb Packages
   apt:
-    deb: https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/amd64/docker-ce-cli_20.10.7~3-0~ubuntu-focal_amd64.deb
+    deb: "{{ download_cache_dir }}/{{ item.deb_file }}"
     state: present
-
-- name: Install Docker CE Engine 20.10.7
-  apt:
-    deb: https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/amd64/docker-ce_20.10.7~3-0~ubuntu-focal_amd64.deb
-    state: present
+  with_items: "{{ docker_deb_packages }}"
 
 - name: Add VM user to 'docker' group
   user:

--- a/roles/docker/vars/main.yml
+++ b/roles/docker/vars/main.yml
@@ -1,0 +1,9 @@
+---
+
+docker_deb_packages:
+- deb_file: containerd.io_1.4.6-1_amd64.deb
+  sha256sum: c11e644e8fcb6fe92ff2be9a9b730b9baee0f467ac7db1d8597437ff232261c8
+- deb_file: docker-ce-cli_20.10.7~3-0~ubuntu-focal_amd64.deb
+  sha256sum: 1c3f6b4804523c77a9ef89d7ee894c2749c2acb2e8de53d3d49a02fc2c9faf51
+- deb_file: docker-ce_20.10.7~3-0~ubuntu-focal_amd64.deb
+  sha256sum: e0a81fcee2e9b97ba8c6c061772e220ff02975a2da9a6c155b1aa9743dc9dfbc

--- a/roles/vscode/vars/main.yml
+++ b/roles/vscode/vars/main.yml
@@ -4,3 +4,5 @@ vscode_sha256sum: a5a50ec014b27656c198e560796f3b41180f3bdb0c19f0005193f79ed47fc8
 
 vscode_extensions:
 - zbr.vscode-ansible
+- ms-azuretools.vscode-docker
+- ms-vscode-remote.remote-containers

--- a/site.yml
+++ b/site.yml
@@ -16,3 +16,4 @@
     - { role: cache, tags: "cache" }
     - { role: git, tags: "git" }
     - { role: vscode, tags: "vscode" }
+    - { role: docker, tags: "docker" }

--- a/spec/test_docker.py
+++ b/spec/test_docker.py
@@ -1,3 +1,7 @@
+import os
+
+def test_vm_user_is_in_docker_group_(host):
+    assert 'docker' in host.user(os.environ['USER']).groups
 
 def test_containerd_package_is_installed_at_version_1_4_6_(host):
     assert host.package('containerd.io').is_installed

--- a/spec/test_docker.py
+++ b/spec/test_docker.py
@@ -1,0 +1,23 @@
+
+def test_containerd_package_is_installed_at_version_1_4_6_(host):
+    assert host.package('containerd.io').is_installed
+    assert '1.4.6' in host.package('containerd.io').version
+
+def test_containerd_version_command_reports_1_4_6_(host):
+    assert '1.4.6' in host.run('containerd -v').stdout
+
+
+def test_docker_cli_package_is_installed_at_version_20_10_7_(host):
+    assert host.package('docker-ce-cli').is_installed
+    assert '20.10.7' in host.package('docker-ce-cli').version
+
+def test_docker_cli_version_command_reports_20_10_7_(host):
+    assert '20.10.7' in host.run('docker -v').stdout
+
+
+def test_docker_engine_package_is_installed_at_version_20_10_7_(host):
+    assert host.package('docker-ce').is_installed
+    assert '20.10.7' in host.package('docker-ce').version
+
+def test_docker_engine_version_command_reports_20_10_7_(host):
+    assert '20.10.7' in host.run('sudo docker version --format "{{.Server.Version}}"').stdout

--- a/spec/test_vscode.py
+++ b/spec/test_vscode.py
@@ -7,8 +7,9 @@ def test_vscode_version_command_reports_version_1_57_1_(host):
     assert '1.57.1' in host.run('code --version').stdout
 
 @pytest.mark.parametrize('extension', [
-    'zbr.vscode-ansible'
+    'zbr.vscode-ansible',
+    'ms-azuretools.vscode-docker',
+    'ms-vscode-remote.remote-containers'
 ])
-def test_vscode_extensions_include_defined_extensions_(host, extension):
-    installed_extensions = host.run('code --list-extensions').stdout
-    assert extension in installed_extensions
+def test_vscode_extension_is_installed_(host, extension):
+    assert extension in host.run('code --list-extensions').stdout


### PR DESCRIPTION
Adds docker to the toolchain, so that we can use this developer VM to build projects with dockerized build toolchains:

* installs Docker CE 20.10.7 
* installs plugins for [VSCode to work with remote containers](https://code.visualstudio.com/docs/remote/containers)
