### PR TITLE
Cache downloading of vscode .deb package

### DIFF
--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -1,8 +1,15 @@
 ---
 
-- name: Install VSCode version 1.57.1 from .deb package
+- name: Download VSCode version {{ vscode_version }} .deb package
+  get_url:
+    url: https://update.code.visualstudio.com/{{ vscode_version }}/linux-deb-x64/stable
+    checksum: "sha256:{{ vscode_sha256sum }}"
+    dest: "{{ download_cache_dir }}/vscode-{{ vscode_version }}.deb"
+    force: no
+
+- name: Install VSCode version {{ vscode_version }} from .deb package
   apt:
-    deb: https://update.code.visualstudio.com/1.57.1/linux-deb-x64/stable
+    deb: "{{ download_cache_dir }}/vscode-{{ vscode_version }}.deb"
     state: present
 
 - name: List VSCode Extensions

--- a/roles/vscode/vars/main.yml
+++ b/roles/vscode/vars/main.yml
@@ -1,3 +1,6 @@
 ---
+vscode_version: 1.57.1
+vscode_sha256sum: a5a50ec014b27656c198e560796f3b41180f3bdb0c19f0005193f79ed47fc8b8
+
 vscode_extensions:
 - zbr.vscode-ansible


### PR DESCRIPTION
Avoids re-downloading the vscode .deb package with every ansible run by caching it in the `/var/cache/downloads` directory.

Also adds a sha256 checksum check and extracts the `vscode_version` and `vscode_sha256sum` into variables.