### PR TITLE
Add download cache directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Other tweaks and settings worth mentioning:
  * sets up `~/.bashrc.d` directory to ease management of bash initialization (e.g. for setting env vars)
  * adds a Git `PS1` shell prompt and configures some useful aliases and settings in `~/.gitconfig`
  * symlinks [`update-vm.sh`](scripts/update-vm.sh) to `/usr/local/bin/update-vm` so it's in the `$PATH` and can be used for updating the VM from the inside (see below)
+ * adds `/var/cache/downloads` as a cache directory for downloaded installer files
 
 
 ## Usage

--- a/roles/cache/handlers/main.yml
+++ b/roles/cache/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: create-systemd-tmpfiles
+  command:
+    cmd: systemd-tmpfiles --create

--- a/roles/cache/handlers/main.yml
+++ b/roles/cache/handlers/main.yml
@@ -1,5 +1,0 @@
----
-
-- name: create-systemd-tmpfiles
-  command:
-    cmd: systemd-tmpfiles --create

--- a/roles/cache/tasks/main.yml
+++ b/roles/cache/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 
-- name: Add systemd-tmpfiles configuration for /var/cache/downloads
+- name: Add systemd-tmpfiles configuration for {{ download_cache_dir }}
   copy:
     content: |
       # See tmpfiles.d(5) for details
 
       # Create a download cache directory without automatic deletion
-      d /var/cache/downloads 1777 root root -
+      d {{ download_cache_dir }} 1777 root root -
     dest: /etc/tmpfiles.d/downloads.conf
     mode: 0644
   notify:

--- a/roles/cache/tasks/main.yml
+++ b/roles/cache/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Add systemd-tmpfiles configuration for /var/cache/downloads
+  copy:
+    content: |
+      # See tmpfiles.d(5) for details
+
+      # Create a download cache directory without automatic deletion
+      d /var/cache/downloads 1777 root root -
+    dest: /etc/tmpfiles.d/downloads.conf
+    mode: 0644
+  register: download_cache
+
+- name: Trigger systemd to create /var/cache/downloads
+  command:
+    cmd: systemd-tmpfiles --create
+    creates: /var/cache/downloads
+  when: download_cache.changed

--- a/roles/cache/tasks/main.yml
+++ b/roles/cache/tasks/main.yml
@@ -9,10 +9,5 @@
       d /var/cache/downloads 1777 root root -
     dest: /etc/tmpfiles.d/downloads.conf
     mode: 0644
-  register: download_cache
-
-- name: Trigger systemd to create /var/cache/downloads
-  command:
-    cmd: systemd-tmpfiles --create
-    creates: /var/cache/downloads
-  when: download_cache.changed
+  notify:
+    - create-systemd-tmpfiles

--- a/roles/cache/tasks/main.yml
+++ b/roles/cache/tasks/main.yml
@@ -9,5 +9,8 @@
       d {{ download_cache_dir }} 1777 root root -
     dest: /etc/tmpfiles.d/downloads.conf
     mode: 0644
-  notify:
-    - create-systemd-tmpfiles
+
+- name: Ensure {{ download_cache_dir }} is created
+  command:
+    cmd: systemd-tmpfiles --create
+    creates: "{{ download_cache_dir }}"

--- a/roles/cache/vars/main.yml
+++ b/roles/cache/vars/main.yml
@@ -1,0 +1,2 @@
+---
+download_cache_dir: /var/cache/downloads

--- a/site.yml
+++ b/site.yml
@@ -13,5 +13,6 @@
     - { role: ansible-lint, tags: "ansible-lint" }
     - { role: testinfra, tags: "testinfra" }
     - { role: bashrc_d, tags: "bashrc_d" }
+    - { role: cache, tags: "cache" }
     - { role: git, tags: "git" }
     - { role: vscode, tags: "vscode" }

--- a/spec/test_cache.py
+++ b/spec/test_cache.py
@@ -1,0 +1,3 @@
+
+def test_download_cache_directory_exists_(host):
+    assert host.file('/var/cache/downloads').is_directory


### PR DESCRIPTION
Adds a permanent download cache directory within VM under `/var/cache/downloads` which is not cleaned up by systemd-tmpfiles