### PR TITLE
Revert to natural become / sudo usage (least privilege by default)

### DIFF
--- a/roles/ansible-lint/tasks/main.yml
+++ b/roles/ansible-lint/tasks/main.yml
@@ -5,3 +5,4 @@
     name: ansible-lint
     version: 5.0.12
     state: present
+  become: yes

--- a/roles/bashrc_d/tasks/main.yml
+++ b/roles/bashrc_d/tasks/main.yml
@@ -4,8 +4,6 @@
     path: ~/.bashrc.d
     state: directory
     mode: 0755
-  become: yes
-  become_user: "{{ ansible_env.SUDO_USER }}"
 
 - name: Setup ~/.bashrc to load .bash files from ~/.bashrc.d
   blockinfile:
@@ -16,5 +14,3 @@
         . "$config"
       done
       unset -v config
-  become: yes
-  become_user: "{{ ansible_env.SUDO_USER }}"

--- a/roles/cache/tasks/main.yml
+++ b/roles/cache/tasks/main.yml
@@ -9,8 +9,10 @@
       d {{ download_cache_dir }} 1777 root root -
     dest: /etc/tmpfiles.d/downloads.conf
     mode: 0644
+  become: yes
 
 - name: Ensure {{ download_cache_dir }} is created
   command:
     cmd: systemd-tmpfiles --create
     creates: "{{ download_cache_dir }}"
+  become: yes

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Add VM user to 'docker' group
   user:
-    name: "{{ ansible_env.SUDO_USER }}"
+    name: "{{ ansible_env.USER }}"
     groups: docker
     append: yes
   become: yes

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -13,9 +13,11 @@
     deb: "{{ download_cache_dir }}/{{ item.deb_file }}"
     state: present
   with_items: "{{ docker_deb_packages }}"
+  become: yes
 
 - name: Add VM user to 'docker' group
   user:
     name: "{{ ansible_env.SUDO_USER }}"
     groups: docker
     append: yes
+  become: yes

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -4,14 +4,13 @@
   apt:
     name: git
     state: present
+  become: yes
 
 - name: Set up the PS1 shell prompt for Git
   copy:
     src: git-ps1.bash
     dest: ~/.bashrc.d/git-ps1.bash
     mode: 0644
-  become: yes
-  become_user: "{{ ansible_env.SUDO_USER }}"
 
 - name: Supply default configuration entries in ~/.gitconfig
   git_config:
@@ -32,5 +31,3 @@
     alias.graph: log --all --oneline --graph --decorate
     alias.stash-all: stash save --include-untracked
     alias.prune: fetch --prune
-  become: yes
-  become_user: "{{ ansible_env.SUDO_USER }}"

--- a/roles/readme/handlers/main.yml
+++ b/roles/readme/handlers/main.yml
@@ -4,3 +4,4 @@
   systemd:
     name: display-manager
     state: restarted
+  become: yes

--- a/roles/readme/tasks/main.yml
+++ b/roles/readme/tasks/main.yml
@@ -5,19 +5,16 @@
     state: present
   notify:
     - restart display-manager
+  become: yes
 
 - name: Ensure the ~/Desktop directory exists
   file:
     path: ~/Desktop
     state: directory
     mode: 0755
-  become: yes
-  become_user: "{{ ansible_env.SUDO_USER }}"
 
 - name: Create the README file on the Desktop
   copy:
     src: README.md
     dest: ~/Desktop/README.md
     mode: 0644
-  become: yes
-  become_user: "{{ ansible_env.SUDO_USER }}"

--- a/roles/testinfra/tasks/main.yml
+++ b/roles/testinfra/tasks/main.yml
@@ -5,9 +5,11 @@
     name: pytest-testinfra
     version: 6.3.0
     state: present
+  become: yes
 
 - name: Install pytest-spec formatter at version 3.2.0
   pip:
     name: pytest-spec
     version: 3.2.0
     state: present
+  become: yes

--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -11,19 +11,16 @@
   apt:
     deb: "{{ download_cache_dir }}/vscode-{{ vscode_version }}.deb"
     state: present
+  become: yes
 
 - name: List VSCode Extensions
   command:
     cmd: code --list-extensions
   register: vscode_installed_extensions
   changed_when: false
-  become: yes
-  become_user: "{{ ansible_env.SUDO_USER }}"
 
 - name: Install VSCode Extensions
   command:
     cmd: code --install-extension "{{ item }}"
   with_items: "{{ vscode_extensions }}"
   when: not vscode_installed_extensions is search(item)
-  become: yes
-  become_user: "{{ ansible_env.SUDO_USER }}"

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -61,7 +61,7 @@ update_vm() {
   local extra_vars=$([[ -f "site.local.yml" ]] && echo "--extra-vars @site.local.yml" || echo "")
 
   step "trigger the Ansible run with $role_tags and $extra_vars"
-  /usr/local/bin/ansible-playbook -i "localhost," -b -c local site.yml -vv $role_tags $extra_vars
+  /usr/local/bin/ansible-playbook -i "localhost," -c local site.yml -vv $role_tags $extra_vars
 }
 
 verify_vm() {

--- a/site.yml
+++ b/site.yml
@@ -6,6 +6,7 @@
       apt:
         update_cache: yes
         cache_valid_time: 3600
+      become: yes
 
 - hosts: localhost
   roles:


### PR DESCRIPTION
For historic reasons I don't really remember anymore, I started this template project off with an inverted / unnatural usage of the [become privilege escalation](https://docs.ansible.com/ansible/2.9/user_guide/become.html), which violates the principle of least privilege:

Previously, before this PR:
* we started `ansible-playbook` with the `-b` / `--become` flag, i.e. with elevated super-user privileges by default
* for tasks that had to run within the actual user's context (e.g. the ones referencing the user's home directory via `~`, or for files being created under the user's permissions) we had to use `become: yes` + `become_user: "{{ ansible_env.SUDO_USER }}"` to have it run under the actual user's context...
* ...which is both unnatural / the wrong default and thus super confusing

Now, with this PR:
* the `-b` / `--become` flag has been removed from the `ansible-playbook` invocation, i.e. by default we run with normal user privileges
* wherever needed (e.g. when using `apt:` etc), we can explicitly escalate to sudo privileges via `become: yes`
* in cases where we need to refer to the current user within the Ansible roles, we can do so via `{{ ansible_env.USER }}`

Thanks @jotbe for pointing this out again and for providing a working spike implementation !