### PR TITLE
Replace VSCode Ansible Plugin & Update Ansible-Lint

### DIFF
--- a/roles/ansible-lint/tasks/main.yml
+++ b/roles/ansible-lint/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Install ansible-lint at version 5.0.12
+- name: Install ansible-lint at version 5.3.2
   pip:
     name: ansible-lint
     version: 5.3.2

--- a/roles/ansible-lint/tasks/main.yml
+++ b/roles/ansible-lint/tasks/main.yml
@@ -3,6 +3,6 @@
 - name: Install ansible-lint at version 5.0.12
   pip:
     name: ansible-lint
-    version: 5.0.12
+    version: 5.3.2
     state: present
   become: yes

--- a/roles/vscode/vars/main.yml
+++ b/roles/vscode/vars/main.yml
@@ -3,6 +3,6 @@ vscode_version: 1.57.1
 vscode_sha256sum: a5a50ec014b27656c198e560796f3b41180f3bdb0c19f0005193f79ed47fc8b8
 
 vscode_extensions:
-- zbr.vscode-ansible
+- redhat.ansible
 - ms-azuretools.vscode-docker
 - ms-vscode-remote.remote-containers

--- a/spec/test_ansible_lint.py
+++ b/spec/test_ansible_lint.py
@@ -1,11 +1,13 @@
 
-def test_ansible_lint_is_installed_at_version_5_0_12_(host):
+def test_ansible_lint_is_installed_at_version_5_3_2_(host):
     cmd = host.run("pip3 show --disable-pip-version-check ansible-lint")
     assert cmd.rc is 0
     assert "Name: ansible-lint\nVersion: 5.3.2" in cmd.stdout
 
+
 def test_ansible_lint_command_is_found_(host):
     assert host.run('which ansible-lint').rc is 0
 
-def test_ansible_lint_version_command_reports_version_5_0_12_(host):
+
+def test_ansible_lint_version_command_reports_version_5_3_2_(host):
     assert '5.3.2' in host.run('ansible-lint --version').stdout

--- a/spec/test_ansible_lint.py
+++ b/spec/test_ansible_lint.py
@@ -2,10 +2,10 @@
 def test_ansible_lint_is_installed_at_version_5_0_12_(host):
     cmd = host.run("pip3 show --disable-pip-version-check ansible-lint")
     assert cmd.rc is 0
-    assert "Name: ansible-lint\nVersion: 5.0.12" in cmd.stdout
+    assert "Name: ansible-lint\nVersion: 5.3.2" in cmd.stdout
 
 def test_ansible_lint_command_is_found_(host):
     assert host.run('which ansible-lint').rc is 0
 
 def test_ansible_lint_version_command_reports_version_5_0_12_(host):
-    assert '5.0.12' in host.run('ansible-lint --version').stdout
+    assert '5.3.2' in host.run('ansible-lint --version').stdout

--- a/spec/test_vscode.py
+++ b/spec/test_vscode.py
@@ -7,7 +7,7 @@ def test_vscode_version_command_reports_version_1_57_1_(host):
     assert '1.57.1' in host.run('code --version').stdout
 
 @pytest.mark.parametrize('extension', [
-    'zbr.vscode-ansible',
+    'redhat.ansible',
     'ms-azuretools.vscode-docker',
     'ms-vscode-remote.remote-containers'
 ])


### PR DESCRIPTION
Hello there

I noticed two errors when booting up the VM with Vagrant:

* The Ansible Plugin for VSCode is depricated (https://marketplace.visualstudio.com/items?itemName=zbr.vscode-ansible), I replaced it with the recommended one from Redhat.
* There is a breaking change in one of the dependencies of ansible-lint. See https://github.com/ansible-community/ansible-lint/issues/1795. To fix this I bumped the version to 5.3.2 to fix this.

Let me know what you think of it!