### PR TITLE
Feature/windows caveats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sh    eol=lf
+*.bash	eol=lf

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ If you want to build a VMware .ova image, you will need a [VMware Workstation (P
 
 All other requirements, including Ansible will be installed *inside the Vagrant VM* during provisioning, i.e. you don't need them installed on your host machine.
 
+The steps below can be executed in the same way on Mac, Linux, and Windows.
+
 ### Building
 
 Bring up the developer VM:
@@ -204,6 +206,8 @@ $ VBoxManage sharedfolder remove "Linux Developer VM" --name "vagrant"
 $ VBoxManage modifyvm "Linux Developer VM" --name "Linux Developer VM v0.1.0"
 $ VBoxManage export "Linux Developer VM v0.1.0" --output "linux-developer-vm-v0.1.0.ova" --options manifest,nomacs
 ```
+
+*Windows users*: You may have to either use the full path to `VBoxManage.exe` or add the Virtualbox path to your `Path` environment variable (recommended): Open the system settings (keyboard shortcut `WIN + X` then `y`), click on "Advanced system settings" > tab "Advanced" > button "Environment Variables" and add `C:\Program Files\Oracle\VirtualBox\` to `Path`.
 
 For VMware:
 ```

--- a/roles/git/files/git-ps1.bash
+++ b/roles/git/files/git-ps1.bash
@@ -1,2 +1,3 @@
 #!/bin/bash
+# Provide a custom Bash prompt for Git
 export PS1='`if [ $? = 0 ]; then echo "\[\e[32m\] ✔ "; else echo "\[\e[31m\] ✘ "; fi`\[\e[00;37m\]\u\[\e[01;37m\]@\[\e[00;37m\]\h\[\e[01;37m\]:\[\e[01;34m\]\w\[\e[00;34m\] `[[ $(git status 2> /dev/null | head -n4 | tail -n1) != "Changes to be committed:" ]] && echo "\[\e[01;31m\]" || echo "\[\e[01;33m\]"``[[ $(git status 2> /dev/null | tail -n1) != "nothing to commit, working tree clean" ]] || echo "\[\e[01;32m\]"`$(__git_ps1 "(%s)")`echo "\[\e[00m\]"`\$ '

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -39,6 +39,8 @@ copy_repo_and_symlink_self() {
   if mountpoint -q /vagrant; then
     step "Copy /vagrant to $REPO_ROOT"
     rsync -avh --progress /vagrant/ $REPO_ROOT/ --delete --exclude-from /vagrant/.gitignore
+    step "Fixing permissions..."
+    chmod 0755 "$REPO_ROOT/scripts/update-vm.sh"
     step "Symlinking 'update-vm' script"
     sudo ln -sf $REPO_ROOT/scripts/update-vm.sh /usr/local/bin/update-vm
   else


### PR DESCRIPTION
Fixes a few caveats when building the developer VM from a windows host:

 * ensures all `*.sh` and `*.bash` files always use LF line endings
 * ensures that `update-vm.sh` is executable when copied into the VM
 * add remarks for Windows users to README