### PR TITLE
Add CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2
+jobs:
+  build:
+    machine:
+      image: ubuntu-2004:current
+    environment:
+      VAGRANT_DEFAULT_PROVIDER: docker
+    steps:
+      - checkout
+      - run:
+          name: Install Vagrant
+          command: |
+            wget https://releases.hashicorp.com/vagrant/2.2.19/vagrant_2.2.19_x86_64.deb
+            sudo dpkg -i vagrant_2.2.19_x86_64.deb
+      - run:
+          name: Bring up Developer VM
+          command: vagrant up --no-provision
+      - run:
+          name: Provision Developer VM
+          command: UPDATE_VM_FLAGS=--provision-only vagrant provision
+      - run:
+          name: Test Developer VM
+          command: UPDATE_VM_FLAGS=--verify-only vagrant provision

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,9 @@ jobs:
           name: Export Test Results
           command: |
             mkdir -p test-results/junit
-            vagrant ssh -c --no-tty 'cat /home/user/vm-setup/out/test/report.xml' > test-results/junit/junit-report.xml
+            vagrant ssh -c 'ls -la /home/user/vm-setup/out/'
+            vagrant ssh -c 'cat /home/user/vm-setup/out/report.xml' > test-results/junit/junit-report.xml
+            vagrant ssh -c 'cat /home/user/vm-setup/out/report.html' > test-results/test-report.html
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,3 +24,12 @@ jobs:
       - run:
           name: Test Developer VM
           command: UPDATE_VM_FLAGS=--verify-only vagrant provision
+      - run:
+          name: Export Test Results
+          command: |
+            mkdir -p test-results/junit
+            vagrant ssh -c --no-tty 'cat /home/user/vm-setup/out/test/report.xml' > test-results/junit/junit-report.xml
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
           name: Bring up Developer VM
           command: vagrant up --no-provision
       - run:
+          name: Inject docker systemctl replacement (required for testing in container only)
+          command: vagrant ssh -c 'sudo wget -O /usr/bin/systemctl https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py'
+      - run:
           name: Provision Developer VM
           command: UPDATE_VM_FLAGS=--provision-only vagrant provision
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant/
 __pycache__/
+out/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 # Linux Developer VM Example / Template
 
+[![Circle CI](https://circleci.com/gh/Zuehlke/linux-developer-vm-with-ansible/tree/master.svg?style=shield)](https://circleci.com/gh/Zuehlke/linux-developer-vm-with-ansible/tree/master)
+
 A minimal example / template project for an Ansible-managed Linux Developer VM.
 
 ![Linux Developer VM Screenshot](https://user-images.githubusercontent.com/365744/124432724-38917880-dd72-11eb-9673-5882a52acf92.png)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,12 @@ Vagrant.configure("2") do |config|
   config.vm.box = "tknerr/ubuntu2004-desktop"
   config.vm.box_version = "0.1.0"
 
+  # override the basebox when testing (an approximation) with docker
+  config.vm.provider :docker do |docker, override|
+    override.vm.box = "tknerr/baseimage-ubuntu-20.04"
+    override.vm.box_version = "1.0.0"
+  end
+
   # hostname
   config.vm.hostname = 'dev-vm'
 

--- a/roles/testinfra/tasks/main.yml
+++ b/roles/testinfra/tasks/main.yml
@@ -13,3 +13,10 @@
     version: 3.2.0
     state: present
   become: yes
+
+- name: Install pytest-html reporter at version 3.1.1
+  pip:
+    name: pytest-html
+    version: 3.1.1
+    state: present
+  become: yes

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -75,7 +75,7 @@ verify_vm() {
   ansible-lint --force-color
 
   step "run integration tests"
-  py.test --color=yes --spec spec/*.py
+  py.test --color=yes --junitxml=out/test/report.xml --spec spec/*.py
 }
 
 big_step() {

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -75,7 +75,7 @@ verify_vm() {
   ansible-lint --force-color
 
   step "run integration tests"
-  py.test --color=yes --junitxml=out/test/report.xml --spec spec/*.py
+  py.test --color=yes --junitxml=out/report.xml --html=out/report.html --self-contained-html --spec spec/*.py
 }
 
 big_step() {

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -38,6 +38,7 @@ copy_repo_and_symlink_self() {
   big_step "Copying repo into the VM..."
   if mountpoint -q /vagrant; then
     step "Copy /vagrant to $REPO_ROOT"
+    sudo apt-get install rsync -y
     rsync -avh --progress /vagrant/ $REPO_ROOT/ --delete --exclude-from /vagrant/.gitignore
     step "Fixing permissions..."
     chmod 0755 "$REPO_ROOT/scripts/update-vm.sh"

--- a/spec/test_docker.py
+++ b/spec/test_docker.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 def test_vm_user_is_in_docker_group_(host):
     assert 'docker' in host.user(os.environ['USER']).groups
@@ -23,5 +24,6 @@ def test_docker_engine_package_is_installed_at_version_20_10_7_(host):
     assert host.package('docker-ce').is_installed
     assert '20.10.7' in host.package('docker-ce').version
 
+@pytest.mark.skipif(os.path.exists('/.dockerenv'), reason = 'skip until docker-in-docker issue are fixed')
 def test_docker_engine_version_command_reports_20_10_7_(host):
     assert '20.10.7' in host.run('sudo docker version --format "{{.Server.Version}}"').stdout

--- a/spec/test_testinfra.py
+++ b/spec/test_testinfra.py
@@ -8,3 +8,8 @@ def test_pytest_spec_is_installed_at_version_3_2_0_(host):
     cmd = host.run("pip3 show --disable-pip-version-check pytest-spec")
     assert cmd.rc is 0
     assert "Name: pytest-spec\nVersion: 3.2.0" in cmd.stdout
+
+def test_pytest_html_formatter_is_installed_at_version_3_1_1_(host):
+    cmd = host.run("pip3 show --disable-pip-version-check pytest-html")
+    assert cmd.rc is 0
+    assert "Name: pytest-html\nVersion: 3.1.1" in cmd.stdout


### PR DESCRIPTION
This PR adds a CI build on CircleCI for the developer VM.

It uses the vagrant docker provider and the [baseimage-ubuntu-20.04](https://app.vagrantup.com/tknerr/boxes/baseimage-ubuntu-20.04) basebox from tknerr/vagrant-docker-baseimages to run `vagrant up` the "VM" with the docker provider. The it runs `update-vm --provision-only` (Ansible provisioning) and `update-vm --verify-only` (Testinfra tests) in separate steps, before collecting and publishing the test reports.

The test for testing the docker installation (in a docker basebox) is currently being skipped -- this will be fixed in a subsequent PR.