### PR TITLE
Fix docker in docker issues (when using vagrant docker provider)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,9 @@ jobs:
           command: vagrant up --no-provision
       - run:
           name: Inject docker systemctl replacement (required for testing in container only)
-          command: vagrant ssh -c 'sudo wget -O /usr/bin/systemctl https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py'
+          command: |
+            vagrant ssh -c 'sudo wget -O /usr/bin/systemctl https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py'
+            vagrant ssh -c 'sudo mkdir -p /run/systemd/system/'
       - run:
           name: Provision Developer VM
           command: UPDATE_VM_FLAGS=--provision-only vagrant provision

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,8 @@ Vagrant.configure("2") do |config|
   config.vm.provider :docker do |docker, override|
     override.vm.box = "tknerr/baseimage-ubuntu-20.04"
     override.vm.box_version = "1.0.0"
+    # docker (in-docker) needs privileges for creating the docker socket
+    docker.create_args = [ "--cap-add=NET_ADMIN" ]
   end
 
   # hostname

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -21,3 +21,17 @@
     groups: docker
     append: yes
   become: yes
+
+- name: Ensure containerd service is started and enabled
+  service:
+    name: containerd
+    state: started
+    enabled: yes
+  become: yes
+
+- name: Ensure docker service is started and enabled
+  service:
+    name: docker
+    state: started
+    enabled: yes
+  become: yes

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -29,6 +29,23 @@
     enabled: yes
   become: yes
 
+- name: Ensure the /etc/systemd/system/docker.service.d override directory exists
+  file:
+    path: /etc/systemd/system/docker.service.d
+    state: directory
+    mode: 0755
+  become: yes
+
+- name: Override docker service configuration (omit '-H fd://' in ExecStart)
+  copy:
+    content: |
+      [Service]
+      ExecStart=
+      ExecStart=/usr/bin/dockerd --containerd=/run/containerd/containerd.sock
+    dest: /etc/systemd/system/docker.service.d/override.conf
+    mode: 0644
+  become: yes
+
 - name: Ensure docker service is started and enabled
   service:
     name: docker

--- a/spec/test_docker.py
+++ b/spec/test_docker.py
@@ -11,6 +11,10 @@ def test_containerd_package_is_installed_at_version_1_4_6_(host):
 def test_containerd_version_command_reports_1_4_6_(host):
     assert '1.4.6' in host.run('containerd -v').stdout
 
+def test_containerd_service_is_enabled_and_running_(host):
+    assert host.service("containerd").is_enabled
+    assert host.service("containerd").is_running
+
 
 def test_docker_cli_package_is_installed_at_version_20_10_7_(host):
     assert host.package('docker-ce-cli').is_installed
@@ -24,6 +28,9 @@ def test_docker_engine_package_is_installed_at_version_20_10_7_(host):
     assert host.package('docker-ce').is_installed
     assert '20.10.7' in host.package('docker-ce').version
 
-@pytest.mark.skipif(os.path.exists('/.dockerenv'), reason = 'skip until docker-in-docker issue are fixed')
 def test_docker_engine_version_command_reports_20_10_7_(host):
     assert '20.10.7' in host.run('sudo docker version --format "{{.Server.Version}}"').stdout
+
+def test_docker_service_is_enabled_and_running_(host):
+    assert host.service("docker").is_enabled
+    assert host.service("docker").is_running

--- a/spec/test_docker.py
+++ b/spec/test_docker.py
@@ -12,8 +12,9 @@ def test_containerd_version_command_reports_1_4_6_(host):
     assert '1.4.6' in host.run('containerd -v').stdout
 
 def test_containerd_service_is_enabled_and_running_(host):
-    assert host.service("containerd").is_enabled
-    assert host.service("containerd").is_running
+    with host.sudo():
+        assert host.service("containerd").is_enabled
+        assert host.service("containerd").is_running
 
 
 def test_docker_cli_package_is_installed_at_version_20_10_7_(host):
@@ -32,5 +33,6 @@ def test_docker_engine_version_command_reports_20_10_7_(host):
     assert '20.10.7' in host.run('sudo docker version --format "{{.Server.Version}}"').stdout
 
 def test_docker_service_is_enabled_and_running_(host):
-    assert host.service("docker").is_enabled
-    assert host.service("docker").is_running
+    with host.sudo():
+        assert host.service("docker").is_enabled
+        assert host.service("docker").is_running


### PR DESCRIPTION
This PR fixes the "docker-in-docker" related issues when using the vagrant docker provider (mostly used for testing on CircleCI).

There were a few pitfalls:

* the "containerd" and "docker" services must be explicitly started, as they don't come up automatically (in docker) after the packages are installed
* Ansible checks for existence of the `/run/systemd/system/` directory when detecting systemd as part of the `service` modules, so this had to be added first
* the docker service could not be started (within docker) when using systemd socket activation (i.e. `-H fd://`), so we had to override the `ExecStart` in the service definition to avoid that
* the docker service then would still not start, as it configures iptables rules which require the `NET_ADMIN` capability, so we added that via `Vagrantfile`
* the Testinfra tests would not detect the containerd and docker services to be running, except when checking with sudo permissions (a bug in gdraheim/docker-systemctl-replacement ?)


Resources:

* https://github.com/gdraheim/docker-systemctl-replacement/blob/master/SERVICE-MANAGER.md#ansible-workaround
* https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-socket-option
* https://stackoverflow.com/questions/43303507/what-does-fd-mean-exactly-in-dockerd-h-fd/43408869#43408869
* https://stackoverflow.com/a/44523905/2388971