### PR TITLE
Fix black screen / kernel panic after reboot by updating to latest fasmat/ubuntu2004-desktop basebox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,8 @@
 Vagrant.configure("2") do |config|
 
   # basebox
-  config.vm.box = "tknerr/ubuntu2004-desktop"
-  config.vm.box_version = "0.1.0"
+  config.vm.box = "fasmat/ubuntu2004-desktop"
+  config.vm.box_version = "22.0306.1"
 
   # override the basebox when testing (an approximation) with docker
   config.vm.provider :docker do |docker, override|


### PR DESCRIPTION
Updates to the latest Ubuntu 20.04 Desktop basebox from @fasmat.

This also fixes an issue with the current basebox, which breaks after installing the most recent updates via Software Updater (it turns into black screen during installation of updates and then hits a kernel panic on subsequent attempts to reboot).

I suspect that a kernel update is involved in the issue, but never figured out completely why that happened.

Updating to a later basebox version (in this case [fasmat/ubuntu2004-desktop](https://app.vagrantup.com/fasmat/boxes/ubuntu2004-desktop/versions/22.0306.1)) resolves the issue as well.


P.S.: this was the black screen upon installation of updates:

<img width="1428" alt="image" src="https://user-images.githubusercontent.com/365744/168793592-59edb2ec-90b5-4173-8bd7-025af581822d.png">

And this was the kernel panic on subsequent reboots (happened equally with both Virtualbox and VMware providers):

<img width="1444" alt="image" src="https://user-images.githubusercontent.com/365744/168793815-9289cd80-96ab-4260-acfa-d8a20bf1cf0e.png">