### PR TITLE
Avoid unintentional VS Code update via Software Updater

### DIFF
--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -24,3 +24,9 @@
     cmd: code --install-extension "{{ item }}"
   with_items: "{{ vscode_extensions }}"
   when: not vscode_installed_extensions is search(item)
+
+- name: Remove vscode apt repos to avoid out-of-band updates
+  file:
+    path: /etc/apt/sources.list.d/vscode.list
+    state: absent
+  become: yes

--- a/spec/test_vscode.py
+++ b/spec/test_vscode.py
@@ -13,3 +13,7 @@ def test_vscode_version_command_reports_version_1_57_1_(host):
 ])
 def test_vscode_extension_is_installed_(host, extension):
     assert extension in host.run('code --list-extensions').stdout
+
+def test_vscode_repo_is_not_present_in_apt_sources_(host):
+    apt_sources = host.run('apt-cache policy').stdout
+    assert 'https://packages.microsoft.com/repos/code' not in apt_sources


### PR DESCRIPTION
As we explicitly want to manage the VS Code version in this Developer VM, we need to remove the https://packages.microsoft.com/repos/code repository which gets added to the apt sources with installation of the vscode .deb package.

(otherwise VScode could easily accidentally be updated when installing updates via Software Updater, and subsequent ansible runs would refute to downgrade and testinfra would fail the tests).

See also:

* https://code.visualstudio.com/docs/setup/linux#_debian-and-ubuntu-based-distributions

