### PR TITLE
Ensure to copy files also when using `--verify-only` flag

### DIFF
--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -89,6 +89,7 @@ step() {
 # main flow
 #
 if [[ "$1" == "--verify-only" ]]; then
+  copy_repo_and_symlink_self
   verify_vm
 else
   check_git


### PR DESCRIPTION
A common use case when developing on the Ansible roles and corresponding tests is to use the `--verify-only` flag of the `update-vm` command.

While this works when the Dev-VM has been imported from the .ova image (and running `update-vm --verify-only` therein), it does not work properly when the Dev-VM is provisioned via vagrant via `UPDATE_VM_FLAGS=--verify-only vagrant provision`.

In the latter case, it will not sync the modified files (most likely tests that you have adapted) into the VM, thus running the tests based on outdated files.

This PR fixes it by making sure that the syncing of all files is happening with the `--verify-only` flag as well.
