### PR TITLE
Fix group memberships when setting up VM user

### DIFF
--- a/scripts/setup-vm-user.sh
+++ b/scripts/setup-vm-user.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# fail early
+set -e -o pipefail
+
 LOGIN_USER=$1
 LOGIN_PASS=$2
 

--- a/scripts/setup-vm-user.sh
+++ b/scripts/setup-vm-user.sh
@@ -15,7 +15,7 @@ fi
 # create user, set password and add it to the usual groups
 adduser $LOGIN_USER --gecos "" --home "/home/$LOGIN_USER" --disabled-password
 echo "$LOGIN_USER:$LOGIN_PASS" | chpasswd
-usermod -a -G adm,cdrom,sudo,dip,plugdev,lpadmin $LOGIN_USER
+usermod -a -G adm,cdrom,sudo,dip,plugdev $LOGIN_USER
 
 # ensure the new user can do passwordless sudo
 echo "$LOGIN_USER ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/$LOGIN_USER

--- a/scripts/setup-vm-user.sh
+++ b/scripts/setup-vm-user.sh
@@ -15,7 +15,7 @@ fi
 # create user, set password and add it to the usual groups
 adduser $LOGIN_USER --gecos "" --home "/home/$LOGIN_USER" --disabled-password
 echo "$LOGIN_USER:$LOGIN_PASS" | chpasswd
-usermod -a -G adm,cdrom,sudo,dip,plugdev,lpadmin,sambashare $LOGIN_USER
+usermod -a -G adm,cdrom,sudo,dip,plugdev,lpadmin $LOGIN_USER
 
 # ensure the new user can do passwordless sudo
 echo "$LOGIN_USER ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/$LOGIN_USER


### PR DESCRIPTION
The assignment of the default groups for ubuntu in `setup-vm-user.sh` failed silently and went unnoticed, because for some reason the "sambashare" group no longer exists in the latest fasmat/ubuntu2004-desktop basebox:

<img width="1344" alt="image" src="https://user-images.githubusercontent.com/365744/168912384-f6f9bfd6-2841-4b91-8856-183816546ab8.png">

As a result, **none of the groups were assigned to the user** and it went unnoticed until I figured out why the Software Updater was no longer working under the VM users account... (it always asked for an Administrator password, as the VM user was not in the "adm" group anymore)

This PR fixes it:

1. makes the `setup-vm-user.sh` script fail early in case *any* command fails
2. removes the "sambashare" group assignment (because that group doesn't exist in the fasmat/ubuntu2004-desktop)
3. removes the "lpadmin" group assignment (because that group doesn't exist in the tknerr/baseimage-ubuntu-20.04)

Even though both are default groups assigned on a stock Ubuntu (see [here](https://askubuntu.com/a/1381087)), I think it is ok to remove them from the Developer VM here.
