### PR TITLE
Add .DS_Store and *.ova files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 out/
 .DS_Store
+*.ova

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vagrant/
 __pycache__/
 out/
+.DS_Store


### PR DESCRIPTION
Add `.DS_Store` and `*.ova` files to `.gitignore`

1. first of all to avoid accidental commits
2. but also the `.gitignore` is respected when rsync'ing contents from the VM shared folder under `/vagrant` into the `~/vm-setup` directory, thus avoids unnecessarily syncing huge .ova files into the VM