### PR TITLE
Remove 'gnome' xsessions so that by default 'ubuntu' is used

### DIFF
--- a/scripts/setup-vm-user.sh
+++ b/scripts/setup-vm-user.sh
@@ -20,6 +20,12 @@ usermod -a -G adm,cdrom,sudo,dip,plugdev $LOGIN_USER
 # ensure the new user can do passwordless sudo
 echo "$LOGIN_USER ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/$LOGIN_USER
 
+# rename gnome xsessions, so that by default ubuntu.desktop will be found and used
+if [[ $(which gnome-session) ]]; then
+  mv /usr/share/xsessions/gnome-xorg.desktop{,.bak}
+  mv /usr/share/xsessions/gnome.desktop{,.bak}
+fi
+
 # set the new user as the default in the login screen and end the current (vagrant) user's gnome session
 mkdir -p /etc/gdm3
 > /etc/gdm3/custom.conf


### PR DESCRIPTION
Depending on the basebox being used, sometimes the "gnome" or "gnome-xorg" GMD sessions are used, instead of the desired "ubuntu" session, which leads to slightly different desktop experience (terminal colors, desktop files not shown, sidebar is missing, etc).

I tried to configure GDM3 in various ways to use the "ubuntu" xsession (e.g. via `/etc/gdm3/custom.conf`), but with no success. In the end, the only reliable way I found was to actually remove or rename the `gnome.desktop` + `gnome-xorg.desktop` xsessions, so that only `ubuntu.desktop` is left. 

This finally did the trick :D