### PR TITLE
Add arm64 / M1 MacBook Support (using Parallels Provider)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,13 @@ $ VMX_FILE=`cat .vagrant/machines/default/vmware_desktop/id`
 $ ovftool --name="Linux Developer VM v0.1.0" "$VMX_FILE" linux-developer-vm-v0.1.0.ova
 ```
 
+For Parallels (via ControlCenter UI):
+* shutdown the running VM (via right-click on VM -> Shutdown)
+* rename the VM to "linux-developer-vm-v0.1.0_arm64" (via right-click on VM -> Configure... -> Name)
+* remove any snapshots (via right-click on VM -> Mange Snapshots... -> Delete)
+* export to .pvmp file (via right-click on VM -> Prepare for Transfer)
+* locate the .pvmp file (via right-click on VM -> Show in Finder) and upload it
+
 Don't forget to throw away the VM when you are done:
 ```
 $ vagrant destroy -f

--- a/README.md
+++ b/README.md
@@ -79,9 +79,11 @@ For general instructions, please refer to the README.md that is placed on the De
 
 ### Prerequisites
 
-You only need [VirtualBox](http://virtualbox.org/wiki/Downloads) and [Vagrant](http://www.vagrantup.com/) installed.
+Minimally, you need [VirtualBox](http://virtualbox.org/wiki/Downloads) and [Vagrant](http://www.vagrantup.com/) installed.
 
-If you want to build a VMware .ova image, you will need a [VMware Workstation (Pro) or VMware Fusion](https://www.vmware.com/products/desktop-hypervisor.html) + [Vagrant VMware Plugin](https://www.vagrantup.com/vmware).
+If you want to build a VMware .ova image, you will need a [VMware Workstation (Pro) or VMware Fusion](https://www.vmware.com/products/desktop-hypervisor.html) + [Vagrant VMware Provider](https://www.vagrantup.com/vmware).
+
+If you want to build a Parallels .pvmp image (**🆕: runs on M1 MacBooks!**), you will need a [Parallels Desktop Pro or Business Edition](https://www.parallels.com/products/desktop/pro/) + [Vagrant Parallels Provider](https://parallels.github.io/vagrant-parallels/docs/).
 
 All other requirements, including Ansible will be installed *inside the Vagrant VM* during provisioning, i.e. you don't need them installed on your host machine.
 

--- a/README.md
+++ b/README.md
@@ -43,53 +43,21 @@ Other tweaks and settings worth mentioning:
  * adds `/var/cache/downloads` as a cache directory for downloaded installer files
 
 
-## Usage
-
-### Obtaining and Starting the VM Image
-
-The latest version of this developer VM can be downloaded as a VM image from here:
-
- * https://github.com/Zuehlke/linux-developer-vm-with-ansible/releases
-
-After downloading the .ova file you can import it into VirtualBox via `File -> Import Appliance...`.
-Once imported, you can simply start the VM and log in:
-
- * username: "user"
- * password: "user"
-
-From then on just open a terminal and you will have all of the tools available (see "What's included?").
-
-### Updating the VM
-
-You can run these commands from anywhere inside the developer VM:
-
- * `update-vm` - update the VM by applying the Ansible roles from the locally checked out repo at `~/vm-setup`
- * `update-vm --pull` - same as above, but update repo before by pulling the latest changes
- * `update-vm --verify-only` - don't update the VM, only run the TestInfra tests
- * `update-vm --provision-only` - don't run the TestInfra tests, only update the vm
-
-### Further Usage Instructions
-
-For general instructions, please refer to the README.md that is placed on the Desktop of the Developer VM:
-
-* [roles/readme/files/README.md](./roles/readme/files/README.md)
-
-
-## Building and Packaging the VM
+## Building the VM
 
 ### Prerequisites
 
 Minimally, you need [VirtualBox](http://virtualbox.org/wiki/Downloads) and [Vagrant](http://www.vagrantup.com/) installed.
 
-If you want to build a VMware .ova image, you will need a [VMware Workstation (Pro) or VMware Fusion](https://www.vmware.com/products/desktop-hypervisor.html) + [Vagrant VMware Provider](https://www.vagrantup.com/vmware).
+➡️ if you want to build a VMware .ova image, you will need a [VMware Workstation (Pro) or VMware Fusion](https://www.vmware.com/products/desktop-hypervisor.html) + [Vagrant VMware Provider](https://www.vagrantup.com/vmware).
 
-If you want to build a Parallels .pvmp image (**🆕: runs on M1 MacBooks!**), you will need a [Parallels Desktop Pro or Business Edition](https://www.parallels.com/products/desktop/pro/) + [Vagrant Parallels Provider](https://parallels.github.io/vagrant-parallels/docs/).
+➡️ if you want to build a Parallels .pvmp image (**runs on M1 MacBooks!**), you will need a [Parallels Desktop Pro or Business Edition](https://www.parallels.com/products/desktop/pro/) + [Vagrant Parallels Provider](https://parallels.github.io/vagrant-parallels/docs/).
 
 All other requirements, including Ansible will be installed *inside the Vagrant VM* during provisioning, i.e. you don't need them installed on your host machine.
 
 The steps below can be executed in the same way on Mac, Linux, and Windows.
 
-### Building
+### Building and Provisioning via Vagrant
 
 Bring up the developer VM:
 ```
@@ -174,7 +142,8 @@ should see all tests passing:
 If these are passing as expected, you can continue developing on the Ansible roles within this repo.
 Please don't forget to add a test for each new feature you add (see "Contributing")
 
-### Packaging
+
+## Packaging / Exporting the VM
 
 Whenever you feel like distributing a fat VM image rather than a Vagrantfile,
 you can package / export it as a VirtualBox image. This might be useful
@@ -231,6 +200,46 @@ Don't forget to throw away the VM when you are done:
 ```
 $ vagrant destroy -f
 ```
+
+
+## Using the Packaged / Exported VM
+
+Consider that not everyone in your team has Vagrant + the necessary plugins installed, so you can just provide them with the exported (yet still updateable) VM image and they are ready to go.
+
+### Obtaining and Starting the VM Image
+
+The latest version of this developer VM can be downloaded as a VM image from here:
+
+ * https://github.com/Zuehlke/linux-developer-vm-with-ansible/releases
+
+After downloading the .ova file you can import it:
+
+* into VirtualBox via `File -> Import Appliance...` (and choose the exported VirtualBox .ova image)
+* into VMware Workstation / Fusion via `File -> Import...` (and choose the exported VMware .ova image)
+* into Parallels Desktop via `File -> Open...` (and choose the exported Parallels .pvmp image)
+
+Once imported, you can simply start the VM and log in:
+
+ * username: "user"
+ * password: "user"
+
+From then on just open a terminal and you will have all of the tools available (see "What's included?").
+
+### Updating the VM
+
+You can run these commands from anywhere inside the developer VM:
+
+ * `update-vm` - update the VM by applying the Ansible roles from the locally checked out repo at `~/vm-setup`
+ * `update-vm --pull` - same as above, but update repo before by pulling the latest changes
+ * `update-vm --verify-only` - don't update the VM, only run the TestInfra tests
+ * `update-vm --provision-only` - don't run the TestInfra tests, only update the vm
+
+### Further Usage Instructions
+
+For general instructions, please refer to the README.md that is placed on the Desktop of the Developer VM:
+
+* [roles/readme/files/README.md](./roles/readme/files/README.md)
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A minimal example / template project for an Ansible-managed Linux Developer VM.
 
-![Linux Developer VM Screenshot](https://user-images.githubusercontent.com/365744/124432724-38917880-dd72-11eb-9673-5882a52acf92.png)
+![Linux Developer VM Screenshot](https://user-images.githubusercontent.com/365744/221720387-c926a3e5-14a4-4b23-9f0e-f2d93577a3b0.png)
 
 
 It's meant to be copy/pasted and filled with life. The `roles/` directory contains the roles
@@ -51,7 +51,7 @@ Minimally, you need [VirtualBox](http://virtualbox.org/wiki/Downloads) and [Vagr
 
 ➡️ if you want to build a VMware .ova image, you will need a [VMware Workstation (Pro) or VMware Fusion](https://www.vmware.com/products/desktop-hypervisor.html) + [Vagrant VMware Provider](https://www.vagrantup.com/vmware).
 
-➡️ if you want to build a Parallels .pvmp image (**runs on M1 MacBooks!**), you will need a [Parallels Desktop Pro or Business Edition](https://www.parallels.com/products/desktop/pro/) + [Vagrant Parallels Provider](https://parallels.github.io/vagrant-parallels/docs/).
+➡️ if you want to build a Parallels .pvmp image, you will need a [Parallels Desktop (Pro Edition / Business Edition)](https://www.parallels.com/products/desktop/pro/) + [Vagrant Parallels Provider](https://parallels.github.io/vagrant-parallels/docs/) (👉 **works on M1 MacBooks!**).
 
 All other requirements, including Ansible will be installed *inside the Vagrant VM* during provisioning, i.e. you don't need them installed on your host machine.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,6 +41,13 @@ Vagrant.configure("2") do |config|
     vmware.vmx["usb_xhci.present"] = "TRUE"
   end
 
+  # parallels specific customizations
+  config.vm.provider "parallels" do |prl, override|
+    prl.customize ["set", :id, "--cpus", "4"]
+    prl.customize ["set", :id, "--memsize", "4096"]
+    prl.customize ["set", :id, "--nested-virt", "on"]
+  end
+
   # create new login user
   config.vm.provision "shell", privileged: true, path: 'scripts/setup-vm-user.sh',
     args: "user user"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,19 @@
 
 Vagrant.configure("2") do |config|
 
+  # see https://github.com/hashicorp/vagrant/issues/12610#issuecomment-1117967936
+  def is_arm64?
+    `uname -m`.strip == "arm64" || `/usr/bin/arch -64 sh -c "sysctl -in sysctl.proc_translated"`.strip == "0"
+  end
+
   # basebox
-  config.vm.box = "tknerr/ubuntu2004-desktop-arm"
-  config.vm.box_version = "0.1.0"
+  if is_arm64?
+    config.vm.box = "tknerr/ubuntu2004-desktop-arm"
+    config.vm.box_version = "0.1.0"
+  else
+    config.vm.box = "tknerr/ubuntu2004-desktop"
+    config.vm.box_version = "22.0520.1"
+  end
 
   # override the basebox when testing (an approximation) with docker
   config.vm.provider :docker do |docker, override|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,6 +46,8 @@ Vagrant.configure("2") do |config|
     prl.customize ["set", :id, "--cpus", "4"]
     prl.customize ["set", :id, "--memsize", "4096"]
     prl.customize ["set", :id, "--nested-virt", "on"]
+    # .pvmp export is only supported with full clones
+    prl.linked_clone = false
   end
 
   # create new login user

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,8 @@
 Vagrant.configure("2") do |config|
 
   # basebox
-  config.vm.box = "fasmat/ubuntu2004-desktop"
-  config.vm.box_version = "22.0306.1"
+  config.vm.box = "tknerr/ubuntu2004-desktop-arm"
+  config.vm.box_version = "0.1.0"
 
   # override the basebox when testing (an approximation) with docker
   config.vm.provider :docker do |docker, override|

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -2,8 +2,8 @@
 
 - name: Download Docker CE .deb Packages
   get_url:
-    url: https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/arm64/{{ item.deb_file }}
-    checksum: "sha256:{{ item.sha256sum }}"
+    url: https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/{{ docker_deb_arch }}/{{ item.deb_file }}
+    checksum: "sha256:{{ item.sha256sum[docker_deb_arch] }}"
     dest: "{{ download_cache_dir }}/{{ item.deb_file }}"
     force: no
   with_items: "{{ docker_deb_packages }}"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Download Docker CE .deb Packages
   get_url:
-    url: https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/amd64/{{ item.deb_file }}
+    url: https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/arm64/{{ item.deb_file }}
     checksum: "sha256:{{ item.sha256sum }}"
     dest: "{{ download_cache_dir }}/{{ item.deb_file }}"
     force: no

--- a/roles/docker/vars/main.yml
+++ b/roles/docker/vars/main.yml
@@ -1,9 +1,16 @@
 ---
 
+docker_deb_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
 docker_deb_packages:
-- deb_file: containerd.io_1.4.6-1_arm64.deb
-  sha256sum: 00157cd5ebc6421a592835aaf5631b5e2f38066047ceec6f1db493dcadfb421b
-- deb_file: docker-ce-cli_20.10.7~3-0~ubuntu-focal_arm64.deb
-  sha256sum: f41b2f66fbdf413037ed2b7502b5c71eb6082a2c436cbcbd5a04d6a45f470476
-- deb_file: docker-ce_20.10.7~3-0~ubuntu-focal_arm64.deb
-  sha256sum: da0154e41d75149e4b66c2885d6937b2382f88dac6f5e1b08c3f0f59bea4d1d4
+- deb_file: containerd.io_1.4.6-1_{{ docker_deb_arch }}.deb
+  sha256sum:
+    amd64: c11e644e8fcb6fe92ff2be9a9b730b9baee0f467ac7db1d8597437ff232261c8
+    arm64: 00157cd5ebc6421a592835aaf5631b5e2f38066047ceec6f1db493dcadfb421b
+- deb_file: docker-ce-cli_20.10.7~3-0~ubuntu-focal_{{ docker_deb_arch }}.deb
+  sha256sum:
+    amd64: 1c3f6b4804523c77a9ef89d7ee894c2749c2acb2e8de53d3d49a02fc2c9faf51
+    arm64: f41b2f66fbdf413037ed2b7502b5c71eb6082a2c436cbcbd5a04d6a45f470476
+- deb_file: docker-ce_20.10.7~3-0~ubuntu-focal_{{ docker_deb_arch }}.deb
+  sha256sum:
+    amd64: e0a81fcee2e9b97ba8c6c061772e220ff02975a2da9a6c155b1aa9743dc9dfbc
+    arm64: da0154e41d75149e4b66c2885d6937b2382f88dac6f5e1b08c3f0f59bea4d1d4

--- a/roles/docker/vars/main.yml
+++ b/roles/docker/vars/main.yml
@@ -1,9 +1,9 @@
 ---
 
 docker_deb_packages:
-- deb_file: containerd.io_1.4.6-1_amd64.deb
-  sha256sum: c11e644e8fcb6fe92ff2be9a9b730b9baee0f467ac7db1d8597437ff232261c8
-- deb_file: docker-ce-cli_20.10.7~3-0~ubuntu-focal_amd64.deb
-  sha256sum: 1c3f6b4804523c77a9ef89d7ee894c2749c2acb2e8de53d3d49a02fc2c9faf51
-- deb_file: docker-ce_20.10.7~3-0~ubuntu-focal_amd64.deb
-  sha256sum: e0a81fcee2e9b97ba8c6c061772e220ff02975a2da9a6c155b1aa9743dc9dfbc
+- deb_file: containerd.io_1.4.6-1_arm64.deb
+  sha256sum: 00157cd5ebc6421a592835aaf5631b5e2f38066047ceec6f1db493dcadfb421b
+- deb_file: docker-ce-cli_20.10.7~3-0~ubuntu-focal_arm64.deb
+  sha256sum: f41b2f66fbdf413037ed2b7502b5c71eb6082a2c436cbcbd5a04d6a45f470476
+- deb_file: docker-ce_20.10.7~3-0~ubuntu-focal_arm64.deb
+  sha256sum: da0154e41d75149e4b66c2885d6937b2382f88dac6f5e1b08c3f0f59bea4d1d4

--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -2,8 +2,8 @@
 
 - name: Download VSCode version {{ vscode_version }} .deb package
   get_url:
-    url: https://update.code.visualstudio.com/{{ vscode_version }}/linux-deb-arm64/stable
-    checksum: "sha256:{{ vscode_sha256sum }}"
+    url: https://update.code.visualstudio.com/{{ vscode_version }}/linux-deb-{{ vscode_arch }}/stable
+    checksum: "sha256:{{ vscode_sha256sum[vscode_arch] }}"
     dest: "{{ download_cache_dir }}/vscode-{{ vscode_version }}.deb"
     force: no
 

--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Download VSCode version {{ vscode_version }} .deb package
   get_url:
-    url: https://update.code.visualstudio.com/{{ vscode_version }}/linux-deb-x64/stable
+    url: https://update.code.visualstudio.com/{{ vscode_version }}/linux-deb-arm64/stable
     checksum: "sha256:{{ vscode_sha256sum }}"
     dest: "{{ download_cache_dir }}/vscode-{{ vscode_version }}.deb"
     force: no

--- a/roles/vscode/vars/main.yml
+++ b/roles/vscode/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 vscode_version: 1.57.1
-vscode_sha256sum: a5a50ec014b27656c198e560796f3b41180f3bdb0c19f0005193f79ed47fc8b8
+vscode_sha256sum: ce23625da8a2399f5ab4f39b65747e0a9d3b9b0258c1d81ea5ceb58a6be6d96b
 
 vscode_extensions:
 - redhat.ansible

--- a/roles/vscode/vars/main.yml
+++ b/roles/vscode/vars/main.yml
@@ -1,6 +1,9 @@
 ---
 vscode_version: 1.57.1
-vscode_sha256sum: ce23625da8a2399f5ab4f39b65747e0a9d3b9b0258c1d81ea5ceb58a6be6d96b
+vscode_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'x64' }}"
+vscode_sha256sum:
+  x64: a5a50ec014b27656c198e560796f3b41180f3bdb0c19f0005193f79ed47fc8b8
+  arm64: ce23625da8a2399f5ab4f39b65747e0a9d3b9b0258c1d81ea5ceb58a6be6d96b
 
 vscode_extensions:
 - redhat.ansible


### PR DESCRIPTION
This PR adds support for creating the "Linux Developer VM" on M1 MacBooks, using the [Vagrant Parallels Provider](https://parallels.github.io/vagrant-parallels/docs/):

* adds support for parallels provider in general (see `Vagrantfile`)
* conditionally uses the [tknerr/ubuntu2004-desktop-**arm**](https://app.vagrantup.com/tknerr/boxes/ubuntu2004-desktop-arm/versions/0.1.0) basebox when running from an M1 MacBook
* selects the correct .deb installation packages (arm64 vs amd64) for vscode and docker depending on the host architecture
* updates the README and adds documentation on how to [export a .pvmp VM image](https://www.parallels.com/blogs/vm-transfer/) via Parallels (which doesn't support .ova export)

Prerequisites:
* you need Parallels Desktop Business or Pro Edition installed
* you need the vagrant-parallels provider installed

Then run this on a M1 MacBook:
```
$ vagrant up --provider parallels
```
