### PR TITLE
Fix failing tests / brittle dependencies

### DIFF
--- a/roles/testinfra/tasks/main.yml
+++ b/roles/testinfra/tasks/main.yml
@@ -14,9 +14,9 @@
     state: present
   become: yes
 
-- name: Install pytest-html reporter at version 3.1.1
+- name: Install pytest-html reporter at version 3.2.0
   pip:
     name: pytest-html
-    version: 3.1.1
+    version: 3.2.0
     state: present
   become: yes

--- a/spec/test_ansible.py
+++ b/spec/test_ansible.py
@@ -5,10 +5,10 @@ def test_ansible_is_installed_at_version_5_5_0_(host):
     assert "Name: ansible\nVersion: 5.5.0" in cmd.stdout
 
 
-def test_ansible_core_is_installed_at_version_2_12_5_(host):
+def test_ansible_core_is_installed_at_version_2_12_x_(host):
     cmd = host.run("pip3 show --disable-pip-version-check ansible-core")
     assert cmd.rc is 0
-    assert "Name: ansible-core\nVersion: 2.12.5" in cmd.stdout
+    assert "Name: ansible-core\nVersion: 2.12." in cmd.stdout
 
 
 def test_ansible_commands_are_found_(host):
@@ -16,5 +16,5 @@ def test_ansible_commands_are_found_(host):
     assert host.run('which ansible-playbook').rc is 0
 
 
-def test_ansible_version_command_reports_core_version_2_12_5_(host):
-    assert 'core 2.12.5' in host.run('ansible --version').stdout
+def test_ansible_version_command_reports_core_version_2_12_x_(host):
+    assert 'core 2.12.' in host.run('ansible --version').stdout

--- a/spec/test_testinfra.py
+++ b/spec/test_testinfra.py
@@ -9,7 +9,7 @@ def test_pytest_spec_is_installed_at_version_3_2_0_(host):
     assert cmd.rc is 0
     assert "Name: pytest-spec\nVersion: 3.2.0" in cmd.stdout
 
-def test_pytest_html_formatter_is_installed_at_version_3_1_1_(host):
+def test_pytest_html_formatter_is_installed_at_version_3_2_0_(host):
     cmd = host.run("pip3 show --disable-pip-version-check pytest-html")
     assert cmd.rc is 0
-    assert "Name: pytest-html\nVersion: 3.1.1" in cmd.stdout
+    assert "Name: pytest-html\nVersion: 3.2.0" in cmd.stdout


### PR DESCRIPTION
Fix failing tests / brittle dependencies:

* Bump pytest-html reporter to version 3.2.0 which [fixes an incompatibility with recent pytest 7.2.x versions](https://github.com/pytest-dev/pytest-html/pull/555) (which don't have the py-xml dependency anymore)
* Ansible 5.x ships with ansible-core 2.12.x as per [the release schedule](https://docs.ansible.com/ansible/latest/roadmap/COLLECTIONS_5.html#ansible-minor-releases), so we can't check stricter than that (we checked for ansible-core 2.12.5 but 2.12.10 gets installed in the meantime with ansible 5.5.0)
