### PR TITLE
Pin the docker systemctl replacement to the correct commit

### DIFF
--- a/roles/docker-hacks/tasks/main.yml
+++ b/roles/docker-hacks/tasks/main.yml
@@ -4,7 +4,7 @@
 # source: https://github.com/gdraheim/docker-systemctl-replacement at 9cbe1a00eb4bdac6ff05b96ca34ec9ed3d8fc06c
 - name: Inject docker systemctl replacement (required for testing in container only)
   get_url:
-    url: https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py
+    url: https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/036f3e49f85689b1fe1ec2e776d4814110645864/files/docker/systemctl3.py
     dest: /usr/bin/systemctl
     mode: 0755
     checksum: sha256:eb0764a6eff4641c478f55a4d4ffe1725059d8cdcbd57f8752fff2c1060e977e


### PR DESCRIPTION
Pin the downloaded systemctl replacement to the specific commit, otherwise we will get the latest version from the repo and thus a checksum mismatch error like this:

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/365744/228055948-3d9b55d7-7194-45f0-b489-c6bbb02a6716.png">

This PR pins the systemctl replacement to the previously known working version at https://github.com/gdraheim/docker-systemctl-replacement/blob/036f3e49f85689b1fe1ec2e776d4814110645864/files/docker/systemctl3.py
