### PR TITLE
Update docker to 24.0.7 /  containerd.io to 1.6.24

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Download Docker CE .deb Packages
   get_url:
-    url: https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/{{ docker_deb_arch }}/{{ item.deb_file }}
+    url: https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/{{ docker_deb_arch }}/{{ item.deb_file }}
     checksum: "sha256:{{ item.sha256sum[docker_deb_arch] }}"
     dest: "{{ download_cache_dir }}/{{ item.deb_file }}"
     force: no

--- a/roles/docker/vars/main.yml
+++ b/roles/docker/vars/main.yml
@@ -2,15 +2,15 @@
 
 docker_deb_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
 docker_deb_packages:
-- deb_file: containerd.io_1.4.6-1_{{ docker_deb_arch }}.deb
-  sha256sum:
-    amd64: c11e644e8fcb6fe92ff2be9a9b730b9baee0f467ac7db1d8597437ff232261c8
-    arm64: 00157cd5ebc6421a592835aaf5631b5e2f38066047ceec6f1db493dcadfb421b
-- deb_file: docker-ce-cli_20.10.7~3-0~ubuntu-focal_{{ docker_deb_arch }}.deb
-  sha256sum:
-    amd64: 1c3f6b4804523c77a9ef89d7ee894c2749c2acb2e8de53d3d49a02fc2c9faf51
-    arm64: f41b2f66fbdf413037ed2b7502b5c71eb6082a2c436cbcbd5a04d6a45f470476
-- deb_file: docker-ce_20.10.7~3-0~ubuntu-focal_{{ docker_deb_arch }}.deb
-  sha256sum:
-    amd64: e0a81fcee2e9b97ba8c6c061772e220ff02975a2da9a6c155b1aa9743dc9dfbc
-    arm64: da0154e41d75149e4b66c2885d6937b2382f88dac6f5e1b08c3f0f59bea4d1d4
+  - deb_file: containerd.io_1.6.24-1_{{ docker_deb_arch }}.deb
+    sha256sum:
+      amd64: 5e57863201a147369d1cc54dcb1493ada00ee22ceb90c49f91adc7a8238cd51f
+      arm64: 7474872c7d9c463bd5ef5e1f4b520ae0e5a345ad825988e0cb6bbd4f51e2e85a
+  - deb_file: docker-ce-cli_24.0.7-1~ubuntu.22.04~jammy_{{ docker_deb_arch }}.deb
+    sha256sum:
+      amd64: bfca81c55faacef808c476e16de548a9b7f1d1e537d24d546aef47df7c598564
+      arm64: 83989f785691da500e3d524ec0ab74cbe67d5f210e955c8e9275536a0173880c
+  - deb_file: docker-ce_24.0.7-1~ubuntu.22.04~jammy_{{ docker_deb_arch }}.deb
+    sha256sum:
+      amd64: 81273f05dbc410d9ec62b264bbef5452bfa892117e82be5a673e8e9a39192699
+      arm64: ef2dc5c54894ed6d10ea7bf529331bcc8ff9ab1fb9f1bbfa75281a5833c8a5d7

--- a/spec/test_docker.py
+++ b/spec/test_docker.py
@@ -4,12 +4,12 @@ import pytest
 def test_vm_user_is_in_docker_group_(host):
     assert 'docker' in host.user(os.environ['USER']).groups
 
-def test_containerd_package_is_installed_at_version_1_4_6_(host):
+def test_containerd_package_is_installed_at_version_1_6_24_(host):
     assert host.package('containerd.io').is_installed
-    assert '1.4.6' in host.package('containerd.io').version
+    assert '1.6.24' in host.package('containerd.io').version
 
-def test_containerd_version_command_reports_1_4_6_(host):
-    assert '1.4.6' in host.run('containerd -v').stdout
+def test_containerd_version_command_reports_1_6_24_(host):
+    assert '1.6.24' in host.run('containerd -v').stdout
 
 def test_containerd_service_is_enabled_and_running_(host):
     with host.sudo():
@@ -17,20 +17,20 @@ def test_containerd_service_is_enabled_and_running_(host):
         assert host.service("containerd").is_running
 
 
-def test_docker_cli_package_is_installed_at_version_20_10_7_(host):
+def test_docker_cli_package_is_installed_at_version_24_0_7_(host):
     assert host.package('docker-ce-cli').is_installed
-    assert '20.10.7' in host.package('docker-ce-cli').version
+    assert '24.0.7' in host.package('docker-ce-cli').version
 
-def test_docker_cli_version_command_reports_20_10_7_(host):
-    assert '20.10.7' in host.run('docker -v').stdout
+def test_docker_cli_version_command_reports_24_0_7_(host):
+    assert '24.0.7' in host.run('docker -v').stdout
 
 
-def test_docker_engine_package_is_installed_at_version_20_10_7_(host):
+def test_docker_engine_package_is_installed_at_version_24_0_7_(host):
     assert host.package('docker-ce').is_installed
-    assert '20.10.7' in host.package('docker-ce').version
+    assert '24.0.7' in host.package('docker-ce').version
 
-def test_docker_engine_version_command_reports_20_10_7_(host):
-    assert '20.10.7' in host.run('sudo docker version --format "{{.Server.Version}}"').stdout
+def test_docker_engine_version_command_reports_24_0_7_(host):
+    assert '24.0.7' in host.run('sudo docker version --format "{{.Server.Version}}"').stdout
 
 def test_docker_service_is_enabled_and_running_(host):
     with host.sudo():


### PR DESCRIPTION
This PR updates the docker toolchain:

* Docker CE CLI to 24.0.7
* Docker CE Engine to 24.0.7
* containerd.io to 1.6.24 