### PR TITLE
Update ansible to latest version 8.6.0

### DIFF
--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 
 # variables
 REPO_ROOT=~/vm-setup
-ANSIBLE_VERSION=5.5.0
+ANSIBLE_VERSION=8.6.0
 
 # exports
 export ANSIBLE_FORCE_COLOR=true

--- a/spec/test_ansible.py
+++ b/spec/test_ansible.py
@@ -1,14 +1,14 @@
 
-def test_ansible_is_installed_at_version_5_5_0_(host):
+def test_ansible_is_installed_at_version_8_6_0_(host):
     cmd = host.run("pip3 show --disable-pip-version-check ansible")
     assert cmd.rc is 0
-    assert "Name: ansible\nVersion: 5.5.0" in cmd.stdout
+    assert "Name: ansible\nVersion: 8.6.0" in cmd.stdout
 
 
-def test_ansible_core_is_installed_at_version_2_12_x_(host):
+def test_ansible_core_is_installed_at_version_2_15_x_(host):
     cmd = host.run("pip3 show --disable-pip-version-check ansible-core")
     assert cmd.rc is 0
-    assert "Name: ansible-core\nVersion: 2.12." in cmd.stdout
+    assert "Name: ansible-core\nVersion: 2.15." in cmd.stdout
 
 
 def test_ansible_commands_are_found_(host):
@@ -16,5 +16,5 @@ def test_ansible_commands_are_found_(host):
     assert host.run('which ansible-playbook').rc is 0
 
 
-def test_ansible_version_command_reports_core_version_2_12_x_(host):
-    assert 'core 2.12.' in host.run('ansible --version').stdout
+def test_ansible_version_command_reports_core_version_2_15_x_(host):
+    assert 'core 2.15.' in host.run('ansible --version').stdout


### PR DESCRIPTION
This PR updates Ansible to latest available version 8.6.0 (and thus ansible-core to 2.15.x)