### PR TITLE
DRAFT: Test both amd64 and arm64 platforms on CircleCI (via QEMU emulation on an ubuntu amd64 machine executor)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,16 @@
 version: 2.1
 
-executors:
-  linux_amd64:
-    machine:
-      image: ubuntu-2004:current
-    resource_class: medium
-  macos_arm64:
-    macos:
-      xcode: 15.0.0
-    resource_class: macos.m1.medium.gen1
-
 jobs:
   build:
     parameters:
-      os:
-        type: executor
-    executor: << parameters.os >>
+      target_platform:
+        type: string
+    machine:
+      image: ubuntu-2004:current
+    resource_class: large
     environment:
       VAGRANT_DEFAULT_PROVIDER: docker
+      DOCKER_DEFAULT_PLATFORM: << parameters.target_platform >>
     steps:
       - checkout
       - run:
@@ -25,6 +18,9 @@ jobs:
           command: |
             wget https://releases.hashicorp.com/vagrant/2.4.0/vagrant_2.4.0-1_amd64.deb
             sudo dpkg -i vagrant_2.4.0-1_amd64.deb
+      - run:
+          name: Install QEMU
+          command: sudo apt update && sudo apt install qemu-user-static -y
       - run:
           name: Bring up Developer VM
           command: vagrant up --no-provision
@@ -52,4 +48,6 @@ workflows:
       - build:
           matrix:
             parameters:
-              os: [linux_amd64, macos_arm64]
+              target_platform:
+                - linux/amd64
+                - linux/arm64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,21 @@
-version: 2
-jobs:
-  build:
+version: 2.1
+
+executors:
+  linux_amd64:
     machine:
       image: ubuntu-2004:current
+    resource_class: medium
+  linux_arm64:
+    machine:
+      image: ubuntu-2004:current
+    resource_class: arm.medium
+
+jobs:
+  build:
+    parameters:
+      os:
+        type: executor
+    executor: << parameters.os >>
     environment:
       VAGRANT_DEFAULT_PROVIDER: docker
     steps:
@@ -32,3 +45,11 @@ jobs:
           path: test-results
       - store_artifacts:
           path: test-results
+
+workflows:
+  all-builds:
+    jobs:
+      - build:
+          matrix:
+            parameters:
+              os: [linux_amd64, linux_arm64]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ executors:
     machine:
       image: ubuntu-2004:current
     resource_class: medium
-  linux_arm64:
-    machine:
-      image: ubuntu-2004:current
-    resource_class: arm.medium
+  macos_arm64:
+    macos:
+      xcode: 15.0.0
+    resource_class: macos.m1.medium.gen1
 
 jobs:
   build:
@@ -52,4 +52,4 @@ workflows:
       - build:
           matrix:
             parameters:
-              os: [linux_amd64, linux_arm64]
+              os: [linux_amd64, macos_arm64]

--- a/roles/docker-hacks/tasks/main.yml
+++ b/roles/docker-hacks/tasks/main.yml
@@ -23,3 +23,14 @@
       export DISPLAY=host.docker.internal:0
     dest: ~/.bashrc.d/x11-display.bash
     mode: "0644"
+
+# note: we can use this to skip problematic parts when running under qemu emulation
+- name: Set fact whether we are running under QEMU emulation or not
+  ansible.builtin.set_fact:
+    running_under_qemu_emulation: "{{ ansible_architecture == 'aarch64' and ansible_processor[1] == 'GenuineIntel' }}"
+- name: Place marker file when running under QEMU emulation
+  ansible.builtin.file:
+    path: /.qemu_emulation
+    state: "{{ 'touch' if running_under_qemu_emulation else 'absent' }}"
+    mode: "0644"
+  become: true

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -52,3 +52,4 @@
     state: started
     enabled: true
   become: true
+  when: not running_under_qemu_emulation|default(false)

--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -18,12 +18,13 @@
     cmd: code --list-extensions
   register: vscode_installed_extensions
   changed_when: false
+  when: not running_under_qemu_emulation|default(false)
 
 - name: Install VSCode Extensions # noqa no-changed-when
   ansible.builtin.command:
     cmd: code --install-extension "{{ item }}"
   with_items: "{{ vscode_extensions }}"
-  when: not vscode_installed_extensions is search(item)
+  when: not vscode_installed_extensions is search(item) and not running_under_qemu_emulation|default(false)
 
 - name: Remove vscode apt repos to avoid out-of-band updates
   ansible.builtin.file:

--- a/spec/test_docker.py
+++ b/spec/test_docker.py
@@ -29,9 +29,11 @@ def test_docker_engine_package_is_installed_at_version_24_0_7_(host):
     assert host.package('docker-ce').is_installed
     assert '24.0.7' in host.package('docker-ce').version
 
+@pytest.mark.skipif(os.path.exists('/.qemu_emulation'), reason = 'docker engine does not start when emulated via QEMU')
 def test_docker_engine_version_command_reports_24_0_7_(host):
     assert '24.0.7' in host.run('sudo docker version --format "{{.Server.Version}}"').stdout
 
+@pytest.mark.skipif(os.path.exists('/.qemu_emulation'), reason = 'docker engine does not start when emulated via QEMU')
 def test_docker_service_is_enabled_and_running_(host):
     with host.sudo():
         assert host.service("docker").is_enabled

--- a/spec/test_vscode.py
+++ b/spec/test_vscode.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 
 def test_vscode_command_is_found_(host):
     assert host.run('which code').rc is 0
@@ -6,6 +7,7 @@ def test_vscode_command_is_found_(host):
 def test_vscode_version_command_reports_version_1_84_1_(host):
     assert '1.84.1' in host.run('code --version').stdout
 
+@pytest.mark.skipif(os.path.exists('/.qemu_emulation'), reason = 'vscode plugins not installed when emulated via QEMU')
 @pytest.mark.parametrize('extension', [
     'redhat.ansible',
     'ms-azuretools.vscode-docker',


### PR DESCRIPTION
So far we were running tests on CircleCI only against the `amd64` platform of the Developer VM. Now that we added support for M1/M2 MacBooks via #46 and #49, we should also run automated tests for the `arm64` platform. 

This is enabled by the recent addition of multi-arch docker base image builds in https://github.com/tknerr/vagrant-docker-baseimages/pull/28, which are now published for both `linux/amd64` and `linux/arm64` platforms.

While the best approach would have been to use the ["arm.medium" machine executors](https://circleci.com/docs/using-arm/) for testing on arm64, that was not feasible because [vagrant releases are currently not published for `linux/arm64` platforms](https://github.com/hashicorp/vagrant-installers/issues/288) 😕.

Another alternative would have been to use the [recently added "macos.m1.large.gen1" macos executors](https://circleci.com/blog/m1-mac-resource-class), but these are currently not available in the free plan (at least [not before May 2024](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024)). 

So for now we use the amd64 "large" machine executor, but run the base image under `arm64` platform via QEMU emulation. This is substantially slower (as expected), and also fails to start the docker deamon. The two issues are:

 1. installing vscode plugins is horribly slow as running `code` is allocating and horrendous amount of memory, e.g. running `code --version` takes ~15s and allocates >8GB memory while it's running
 2. the docker daemon does not start up correctly because of `failed to start daemon: Error initializing network controller: error obtaining controller instance: failed to create NAT chain DOCKER: iptables failed: iptables -t nat -N DOCKER: iptables/1.8.7 Failed to initialize nft: Protocol not supported`, which seems to be [a known issue](https://github.com/docker/for-mac/issues/6297) when running iptables in qemu user emulation (see `/var/log/journal/docker.service.log`)