### PR TITLE
Extend CircleCI tests to run both on amd64 and arm64 machine executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,8 @@ jobs:
             # see https://github.com/hashicorp/vagrant-installers/issues/288
             sudo apt update
             sudo apt install vagrant -y
+            # use system ruby instead of any of the rvm rubies to make vagrant work on the arm executor where rvm is installed
+            echo 'which rvm && rvm use system' >> ~/.bashrc
       - run:
           name: Bring up Developer VM
           command: vagrant up --no-provision

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,10 @@ jobs:
       - run:
           name: Install Vagrant
           command: |
-            wget https://releases.hashicorp.com/vagrant/2.4.0/vagrant_2.4.0-1_amd64.deb
-            sudo dpkg -i vagrant_2.4.0-1_amd64.deb
+            # install vagrant (v2.2.19) from apt repositories because there are no official vagrant .deb releases for arm64
+            # see https://github.com/hashicorp/vagrant-installers/issues/288
+            sudo apt update
+            sudo apt install vagrant -y
       - run:
           name: Bring up Developer VM
           command: vagrant up --no-provision

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,21 @@
-version: 2
+version: 2.1
+
+executors:
+  amd64:
+    machine:
+      image: ubuntu-2204:2023.10.1
+    resource_class: medium
+  arm64:
+    machine:
+      image: ubuntu-2204:2023.10.1
+    resource_class: arm.medium
+
 jobs:
   build:
-    machine:
-      image: ubuntu-2004:current
+    parameters:
+      executor:
+        type: executor
+    executor: << parameters.executor >>
     environment:
       VAGRANT_DEFAULT_PROVIDER: docker
     steps:
@@ -32,3 +45,13 @@ jobs:
           path: test-results
       - store_artifacts:
           path: test-results
+
+workflows:
+  all-builds:
+    jobs:
+      - build:
+          matrix:
+            parameters:
+              executor:
+                - amd64
+                - arm64

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.box = "tknerr/ubuntu2204-desktop"
   config.vm.box_version = "23.1027.1"
-  config.vm.box_architecture = :auto
 
   # override the basebox when testing (an approximation) with docker
   config.vm.provider :docker do |docker, override|


### PR DESCRIPTION
So far we were running tests on CircleCI only against the `amd64` platform of the Developer VM. Now that we added support for M1/M2 MacBooks via #46 and #49, we should also run automated tests for the `arm64` platform. 

This is enabled by the recent addition of multi-arch docker base image builds in https://github.com/tknerr/vagrant-docker-baseimages/pull/28, which are now published for both `linux/amd64` and `linux/arm64` platforms.

This PR adds a matrix build configuration to build on both amd64 and arm64 ubuntu machine executors in parallel.